### PR TITLE
Improve hashing performance

### DIFF
--- a/api/apihttp/apihttp_test.go
+++ b/api/apihttp/apihttp_test.go
@@ -214,7 +214,7 @@ func TestMembership(t *testing.T) {
 			version,
 			version+1,
 			[]byte{0x0},
-			new(hashing.Sha256Hasher),
+			hashing.NewSha256Hasher(),
 		)
 	}()
 
@@ -258,10 +258,10 @@ func TestIncremental(t *testing.T) {
 	}
 	go func() {
 		incch <- balloon.NewIncrementalProof(
-			start, 
-			end, 
+			start,
+			end,
 			proof.AuditPath{"0|0": []uint8{0x0}},
-			new(hashing.Sha256Hasher),
+			hashing.NewSha256Hasher(),
 		)
 	}()
 

--- a/balloon/balloon_test.go
+++ b/balloon/balloon_test.go
@@ -212,7 +212,7 @@ func TestVerify(t *testing.T) {
 			c.queryVersion,
 			c.actualVersion,
 			event,
-			new(hashing.Sha256Hasher),
+			hashing.NewSha256Hasher(),
 		)
 		result := proof.Verify(commitment, event)
 
@@ -250,11 +250,10 @@ func BenchmarkAddBolt(b *testing.B) {
 	defer deleteFilesInDir(path)
 
 	cache := cache.NewSimpleCache(1 << 25)
-	hasher := new(hashing.Sha256Hasher)
 
-	hyperT := hyper.NewTree(string(0x0), cache, leaves, hasher)
-	historyT := history.NewTree(string(0x0), frozen, hasher)
-	balloon := NewHyperBalloon(hasher, historyT, hyperT)
+	hyperT := hyper.NewTree(string(0x0), cache, leaves, hashing.NewSha256Hasher())
+	historyT := history.NewTree(string(0x0), frozen, hashing.NewSha256Hasher())
+	balloon := NewHyperBalloon(hashing.NewSha256Hasher(), historyT, hyperT)
 
 	b.ResetTimer()
 	b.N = 10000
@@ -277,11 +276,10 @@ func BenchmarkAddBadger(b *testing.B) {
 	defer deleteFilesInDir(path)
 
 	cache := cache.NewSimpleCache(1 << 25)
-	hasher := new(hashing.Sha256Hasher)
 
-	hyperT := hyper.NewTree(string(0x0), cache, leaves, hasher)
-	historyT := history.NewTree(string(0x0), frozen, hasher)
-	balloon := NewHyperBalloon(hasher, historyT, hyperT)
+	hyperT := hyper.NewTree(string(0x0), cache, leaves, hashing.NewSha256Hasher())
+	historyT := history.NewTree(string(0x0), frozen, hashing.NewSha256Hasher())
+	balloon := NewHyperBalloon(hashing.NewSha256Hasher(), historyT, hyperT)
 
 	b.ResetTimer()
 	b.N = 10000

--- a/balloon/history/incremental_test.go
+++ b/balloon/history/incremental_test.go
@@ -72,8 +72,7 @@ func TestProveAndVerifyConsecutivelyN(t *testing.T) {
 	frozen, close := openBPlusStorage()
 	defer close()
 
-	hasher := new(hashing.Sha256Hasher)
-	tree := NewTree("treeId", frozen, hasher)
+	tree := NewTree("treeId", frozen, hashing.NewSha256Hasher())
 
 	const size int = 10
 	eventDigests := make([][]byte, size)
@@ -96,8 +95,7 @@ func TestProveAndVerifyNonConsecutively(t *testing.T) {
 	frozen, close := openBPlusStorage()
 	defer close()
 
-	hasher := new(hashing.Sha256Hasher)
-	tree := NewTree("treeId", frozen, hasher)
+	tree := NewTree("treeId", frozen, hashing.NewSha256Hasher())
 
 	const size int = 10
 	eventDigests := make([][]byte, size)

--- a/balloon/history/proof_test.go
+++ b/balloon/history/proof_test.go
@@ -89,7 +89,7 @@ func TestAddAndVerifySha256(t *testing.T) {
 	frozen, closeF := openBPlusStorage()
 	defer closeF()
 
-	hasher := new(hashing.Sha256Hasher)
+	hasher := hashing.NewSha256Hasher()
 	ht := NewTree(string(0x0), frozen, hasher)
 
 	key := hasher.Do([]byte("a test event"))

--- a/balloon/history/tree_test.go
+++ b/balloon/history/tree_test.go
@@ -314,7 +314,7 @@ func TestProveIncrementalSameVersions(t *testing.T) {
 func BenchmarkAdd(b *testing.B) {
 	store, closeF := openBadgerStorage()
 	defer closeF()
-	ht := NewTree("treeId", store, new(hashing.Sha256Hasher))
+	ht := NewTree("treeId", store, hashing.NewSha256Hasher())
 	b.N = 100000
 	for i := 0; i < b.N; i++ {
 		key := rand.Bytes(64)

--- a/balloon/hyper/proof_test.go
+++ b/balloon/hyper/proof_test.go
@@ -96,7 +96,7 @@ func TestAddAndVerifySha256(t *testing.T) {
 	leaves, closeF := openBPlusStorage()
 	defer closeF()
 
-	hasher := new(hashing.Sha256Hasher)
+	hasher := hashing.NewSha256Hasher()
 	ht := NewTree(string(0x0), cache.NewSimpleCache(0), leaves, hasher)
 
 	key := hasher.Do([]byte("a test event"))

--- a/balloon/hyper/tree.go
+++ b/balloon/hyper/tree.go
@@ -43,6 +43,7 @@ type Tree struct {
 // NewTree returns  a new Hyper Tree given all its dependencies
 func NewTree(id string, cache Cache, leaves Store, hasher hashing.Hasher) *Tree {
 	var m sync.RWMutex
+
 	cacheLevels := uint64(math.Max(0.0, math.Floor(math.Log(float64(cache.Size()))/math.Log(2.0))))
 	numBits := hasher.Len()
 

--- a/balloon/hyper/tree_test.go
+++ b/balloon/hyper/tree_test.go
@@ -79,7 +79,7 @@ func BenchmarkAdd(b *testing.B) {
 	store, closeF := openBadgerStorage("/var/tmp/hyper_tree_test.db") //openBoltStorage()
 	defer closeF()
 
-	hasher := new(hashing.Sha256Hasher)
+	hasher := hashing.NewSha256Hasher()
 	cache := cache.NewSimpleCache(1 << 25)
 	ht := NewTree(string(0x0), cache, store, hasher)
 	b.ResetTimer()

--- a/cmd/client_incremental.go
+++ b/cmd/client_incremental.go
@@ -67,7 +67,7 @@ func newIncrementalCommand(ctx *clientContext) *cobra.Command {
 
 				log.Infof("Verifying with commitments: \n\tStartDigest: %s\n\tEndDigest: %s\n",
 					startDigest, endDigest)
-				if ctx.client.VerifyIncremental(proof, startSnapshot, endSnapshot, new(hashing.Sha256Hasher)) {
+				if ctx.client.VerifyIncremental(proof, startSnapshot, endSnapshot, hashing.NewSha256Hasher()) {
 					log.Info("Verify: OK")
 				} else {
 					log.Info("Verify: KO")

--- a/cmd/client_membership.go
+++ b/cmd/client_membership.go
@@ -67,7 +67,7 @@ func newMembershipCommand(ctx *clientContext) *cobra.Command {
 
 				log.Infof("Verifying with commitment: \n\tHyperDigest: %s\n\tHistoryDigest: %s\n\tVersion: %d\n",
 					hyperDigest, historyDigest, version)
-				if ctx.client.Verify(proof, snapshot, new(hashing.Sha256Hasher)) {
+				if ctx.client.Verify(proof, snapshot, hashing.NewSha256Hasher()) {
 					log.Info("Verify: OK")
 				} else {
 					log.Info("Verify: KO")

--- a/hashing/hasher.go
+++ b/hashing/hasher.go
@@ -18,7 +18,10 @@
 // implementations.
 package hashing
 
-import "crypto/sha256"
+import (
+	"crypto/sha256"
+	"hash"
+)
 
 // Hasher is the public interface to be used as placeholder for the concrete
 // implementations.
@@ -29,16 +32,23 @@ type Hasher interface {
 
 // Sha256Hasher implements the Hasher interface and computes the crypto/sha256
 // internal function.
-type Sha256Hasher struct{}
+type Sha256Hasher struct {
+	underlying hash.Hash
+}
+
+func NewSha256Hasher() *Sha256Hasher {
+	return &Sha256Hasher{underlying: sha256.New()}
+}
 
 func (s Sha256Hasher) Do(data ...[]byte) []byte {
-	hasher := sha256.New()
+
+	s.underlying.Reset()
 
 	for i := 0; i < len(data); i++ {
-		hasher.Write(data[i])
+		s.underlying.Write(data[i])
 	}
 
-	return hasher.Sum(nil)[:]
+	return s.underlying.Sum(nil)[:]
 }
 
 func (s Sha256Hasher) Len() uint64 { return uint64(256) }

--- a/server/server.go
+++ b/server/server.go
@@ -93,7 +93,7 @@ func NewServer(
 		nil,
 	}
 	if tamper {
-		server.tamperingServer = newTamperingServer("localhost:8081", leaves.(tampering.DeletableStore), new(hashing.Sha256Hasher))
+		server.tamperingServer = newTamperingServer("localhost:8081", leaves.(tampering.DeletableStore), hashing.NewSha256Hasher())
 	}
 
 	if profiling {
@@ -194,10 +194,9 @@ func buildStorageEngine(storageName, dbPath string) (Store, Store, error) {
 
 func buildBalloon(frozen, leaves Store, apiKey string, cacheSize uint64) (*balloon.HyperBalloon, error) {
 	cache := cache.NewSimpleCache(cacheSize)
-	hasher := new(hashing.Sha256Hasher)
-	history := history.NewTree(apiKey, frozen, hasher)
-	hyper := hyper.NewTree(apiKey, cache, leaves, hasher)
-	return balloon.NewHyperBalloon(hasher, history, hyper), nil
+	history := history.NewTree(apiKey, frozen, hashing.NewSha256Hasher())
+	hyper := hyper.NewTree(apiKey, cache, leaves, hashing.NewSha256Hasher())
+	return balloon.NewHyperBalloon(hashing.NewSha256Hasher(), history, hyper), nil
 }
 
 func newHTTPServer(endpoint string, balloon *balloon.HyperBalloon, signer sign.Signable) *http.Server {

--- a/tests/e2e/add_verify_test.go
+++ b/tests/e2e/add_verify_test.go
@@ -83,7 +83,7 @@ func TestAddVerify(t *testing.T) {
 				first.Snapshot.Version,
 				first.Snapshot.Event,
 			}
-			assert.True(t, client.Verify(result, snap, new(hashing.Sha256Hasher)), "The proofs should be valid")
+			assert.True(t, client.Verify(result, snap, hashing.NewSha256Hasher()), "The proofs should be valid")
 		})
 
 	})
@@ -117,7 +117,7 @@ func TestAddVerify(t *testing.T) {
 				s[j].Snapshot.Version,
 				s[i].Snapshot.Event,
 			}
-			assert.True(t, client.Verify(p1, snap, new(hashing.Sha256Hasher)), "p1 should be valid")
+			assert.True(t, client.Verify(p1, snap, hashing.NewSha256Hasher()), "p1 should be valid")
 
 			snap = &apihttp.Snapshot{
 				s[k].Snapshot.HistoryDigest,
@@ -125,7 +125,7 @@ func TestAddVerify(t *testing.T) {
 				s[k].Snapshot.Version,
 				s[i].Snapshot.Event,
 			}
-			assert.True(t, client.Verify(p2, snap, new(hashing.Sha256Hasher)), "p2 should be valid")
+			assert.True(t, client.Verify(p2, snap, hashing.NewSha256Hasher()), "p2 should be valid")
 
 		})
 

--- a/tests/e2e/incremental_test.go
+++ b/tests/e2e/incremental_test.go
@@ -56,7 +56,7 @@ func TestIncrementalConsistency(t *testing.T) {
 		})
 
 		let("Verify the proof", func(t *testing.T) {
-			assert.True(t, client.VerifyIncremental(result, snapshots[2], snapshots[8], new(hashing.Sha256Hasher)), "The proofs should be valid")
+			assert.True(t, client.VerifyIncremental(result, snapshots[2], snapshots[8], hashing.NewSha256Hasher()), "The proofs should be valid")
 		})
 
 	})

--- a/tests/integration/balloon_test.go
+++ b/tests/integration/balloon_test.go
@@ -40,7 +40,7 @@ import (
 
 func TestAddAndVerify(t *testing.T) {
 
-	hasher := new(hashing.Sha256Hasher)
+	hasher := hashing.NewSha256Hasher()
 	b, _, closeF := createBalloon("treeId", hasher)
 	defer closeF()
 
@@ -71,7 +71,7 @@ func TestAddAndVerify(t *testing.T) {
 
 func TestTamperAndVerify(t *testing.T) {
 
-	hasher := new(hashing.Sha256Hasher)
+	hasher := hashing.NewSha256Hasher()
 	b, store, closeF := createBalloon("treeId", hasher)
 	defer closeF()
 
@@ -143,7 +143,7 @@ func TestTamperAndVerify(t *testing.T) {
 
 func TestDeleteAndVerify(t *testing.T) {
 
-	hasher := new(hashing.Sha256Hasher)
+	hasher := hashing.NewSha256Hasher()
 	b, store, closeF := createBalloon("treeId", hasher)
 	defer closeF()
 
@@ -209,7 +209,7 @@ func TestDeleteAndVerify(t *testing.T) {
 }
 
 func TestGenIncrementalAndVerify(t *testing.T) {
-	hasher := new(hashing.Sha256Hasher)
+	hasher := hashing.NewSha256Hasher()
 	b, _, closeF := createBalloon("treeId", hasher)
 	defer closeF()
 	size := 10


### PR DESCRIPTION
We have improved performance by not instantiating the **hasher** whenever the Do() method is called.