### PR TITLE
Fix sync.Mutex passed by value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ before_script:
 
 script:
   - go test -v -coverprofile=coverage.txt -covermode=atomic ./...
+  - go vet -composites=false ./...
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/balloon/history/tree.go
+++ b/balloon/history/tree.go
@@ -30,7 +30,7 @@ import (
 )
 
 type HistoryTree struct {
-	lock    sync.RWMutex
+	lock    *sync.RWMutex
 	hasherF func() hashing.Hasher
 	cache   cache.ModifiableCache
 	hasher  hashing.Hasher
@@ -38,7 +38,7 @@ type HistoryTree struct {
 
 func NewHistoryTree(hasherF func() hashing.Hasher, cache cache.ModifiableCache) *HistoryTree {
 	var lock sync.RWMutex
-	return &HistoryTree{lock, hasherF, cache, hasherF()}
+	return &HistoryTree{&lock, hasherF, cache, hasherF()}
 }
 
 func (t *HistoryTree) getDepth(version uint64) uint16 {

--- a/balloon/hyper/tree.go
+++ b/balloon/hyper/tree.go
@@ -32,7 +32,7 @@ import (
 )
 
 type HyperTree struct {
-	lock          sync.RWMutex
+	lock          *sync.RWMutex
 	store         storage.Store
 	cache         cache.ModifiableCache
 	hasherF       func() hashing.Hasher
@@ -46,7 +46,7 @@ func NewHyperTree(hasherF func() hashing.Hasher, store storage.Store, cache cach
 	hasher := hasherF()
 	cacheLevel := hasher.Len() - uint16(math.Max(float64(2), math.Floor(float64(hasher.Len())/10)))
 	tree := &HyperTree{
-		lock:          lock,
+		lock:          &lock,
 		store:         store,
 		cache:         cache,
 		hasherF:       hasherF,

--- a/log/logger_debug.go
+++ b/log/logger_debug.go
@@ -38,29 +38,29 @@ func newDebug(out io.Writer, prefix string, flag int) *debugLogger {
 }
 
 // A impl 'l debugLogger' qed/log.Logger
-func (l debugLogger) Error(v ...interface{}) {
+func (l *debugLogger) Error(v ...interface{}) {
 	l.Output(caller, fmt.Sprint(v...))
 	osExit(1)
 }
 
-func (l debugLogger) Info(v ...interface{}) {
+func (l *debugLogger) Info(v ...interface{}) {
 	l.Output(caller, fmt.Sprint(v...))
 }
 
-func (l debugLogger) Debug(v ...interface{}) {
+func (l *debugLogger) Debug(v ...interface{}) {
 	l.Output(caller, fmt.Sprint(v...))
 }
 
-func (l debugLogger) Errorf(format string, v ...interface{}) {
+func (l *debugLogger) Errorf(format string, v ...interface{}) {
 	l.Output(caller, fmt.Sprintf(format, v...))
 	osExit(1)
 }
 
-func (l debugLogger) Infof(format string, v ...interface{}) {
+func (l *debugLogger) Infof(format string, v ...interface{}) {
 	l.Output(caller, fmt.Sprintf(format, v...))
 }
 
-func (l debugLogger) Debugf(format string, v ...interface{}) {
+func (l *debugLogger) Debugf(format string, v ...interface{}) {
 	l.Output(caller, fmt.Sprintf(format, v...))
 }
 

--- a/log/logger_error.go
+++ b/log/logger_error.go
@@ -38,20 +38,20 @@ func newError(out io.Writer, prefix string, flag int) *errorLogger {
 }
 
 // A impl 'l errorLogger' qed/log.Logger
-func (l errorLogger) Error(v ...interface{}) {
+func (l *errorLogger) Error(v ...interface{}) {
 	l.Output(caller, fmt.Sprint(v...))
 	osExit(1)
 }
 
-func (l errorLogger) Errorf(format string, v ...interface{}) {
+func (l *errorLogger) Errorf(format string, v ...interface{}) {
 	l.Output(caller, fmt.Sprintf(format, v...))
 	osExit(1)
 }
 
-func (l errorLogger) Info(v ...interface{})                  { return }
-func (l errorLogger) Debug(v ...interface{})                 { return }
-func (l errorLogger) Infof(format string, v ...interface{})  { return }
-func (l errorLogger) Debugf(format string, v ...interface{}) { return }
+func (l *errorLogger) Info(v ...interface{})                  { return }
+func (l *errorLogger) Debug(v ...interface{})                 { return }
+func (l *errorLogger) Infof(format string, v ...interface{})  { return }
+func (l *errorLogger) Debugf(format string, v ...interface{}) { return }
 
 func (l *errorLogger) GetLogger() *log.Logger {
 	return &l.Logger

--- a/log/logger_info.go
+++ b/log/logger_info.go
@@ -38,26 +38,26 @@ func newInfo(out io.Writer, prefix string, flag int) *infoLogger {
 }
 
 // A impl 'l infoLogger' qed/log.Logger
-func (l infoLogger) Error(v ...interface{}) {
+func (l *infoLogger) Error(v ...interface{}) {
 	l.Output(caller, fmt.Sprint(v...))
 	osExit(1)
 }
 
-func (l infoLogger) Info(v ...interface{}) {
+func (l *infoLogger) Info(v ...interface{}) {
 	l.Output(caller, fmt.Sprint(v...))
 }
 
-func (l infoLogger) Errorf(format string, v ...interface{}) {
+func (l *infoLogger) Errorf(format string, v ...interface{}) {
 	l.Output(caller, fmt.Sprintf(format, v...))
 	osExit(1)
 }
 
-func (l infoLogger) Infof(format string, v ...interface{}) {
+func (l *infoLogger) Infof(format string, v ...interface{}) {
 	l.Output(caller, fmt.Sprintf(format, v...))
 }
 
-func (l infoLogger) Debug(v ...interface{})                 { return }
-func (l infoLogger) Debugf(format string, v ...interface{}) { return }
+func (l *infoLogger) Debug(v ...interface{})                 { return }
+func (l *infoLogger) Debugf(format string, v ...interface{}) { return }
 
 func (l *infoLogger) GetLogger() *log.Logger {
 	return &l.Logger

--- a/log/logger_silent.go
+++ b/log/logger_silent.go
@@ -34,12 +34,12 @@ func newSilent() *silentLogger {
 }
 
 // A impl 'l Nologger' qed/log.Logger
-func (l silentLogger) Error(v ...interface{})                 { osExit(1) }
-func (l silentLogger) Info(v ...interface{})                  { return }
-func (l silentLogger) Debug(v ...interface{})                 { return }
-func (l silentLogger) Errorf(format string, v ...interface{}) { osExit(1) }
-func (l silentLogger) Infof(format string, v ...interface{})  { return }
-func (l silentLogger) Debugf(format string, v ...interface{}) { return }
+func (l *silentLogger) Error(v ...interface{})                 { osExit(1) }
+func (l *silentLogger) Info(v ...interface{})                  { return }
+func (l *silentLogger) Debug(v ...interface{})                 { return }
+func (l *silentLogger) Errorf(format string, v ...interface{}) { osExit(1) }
+func (l *silentLogger) Infof(format string, v ...interface{})  { return }
+func (l *silentLogger) Debugf(format string, v ...interface{}) { return }
 
 func (l *silentLogger) GetLogger() *log.Logger {
 	return &l.Logger

--- a/raftwal/fsm.go
+++ b/raftwal/fsm.go
@@ -85,11 +85,11 @@ func NewBalloonFSM(store storage.ManagedStore, hasherF func() hashing.Hasher) (*
 	}, nil
 }
 
-func (fsm BalloonFSM) QueryMembership(event []byte, version uint64) (*balloon.MembershipProof, error) {
+func (fsm *BalloonFSM) QueryMembership(event []byte, version uint64) (*balloon.MembershipProof, error) {
 	return fsm.balloon.QueryMembership(event, version)
 }
 
-func (fsm BalloonFSM) QueryConsistency(start, end uint64) (*balloon.IncrementalProof, error) {
+func (fsm *BalloonFSM) QueryConsistency(start, end uint64) (*balloon.IncrementalProof, error) {
 	return fsm.balloon.QueryConsistency(start, end)
 }
 

--- a/raftwal/raft.go
+++ b/raftwal/raft.go
@@ -278,7 +278,7 @@ func (b *RaftBalloon) Close(wait bool) error {
 }
 
 // Wait until node becomes leader or time is out
-func (b RaftBalloon) WaitForLeader(timeout time.Duration) (string, error) {
+func (b *RaftBalloon) WaitForLeader(timeout time.Duration) (string, error) {
 	tck := time.NewTicker(leaderWaitDelay)
 	defer tck.Stop()
 	tmr := time.NewTimer(timeout)
@@ -297,29 +297,29 @@ func (b RaftBalloon) WaitForLeader(timeout time.Duration) (string, error) {
 	}
 }
 
-func (b RaftBalloon) IsLeader() bool {
+func (b *RaftBalloon) IsLeader() bool {
 	return b.raft.api.State() == raft.Leader
 }
 
 // Addr returns the address of the store.
-func (b RaftBalloon) Addr() string {
+func (b *RaftBalloon) Addr() string {
 	return string(b.raft.transport.LocalAddr())
 }
 
 // LeaderAddr returns the Raft address of the current leader. Returns a
 // blank string if there is no leader.
-func (b RaftBalloon) LeaderAddr() string {
+func (b *RaftBalloon) LeaderAddr() string {
 	return string(b.raft.api.Leader())
 }
 
 // ID returns the Raft ID of the store.
-func (b RaftBalloon) ID() string {
+func (b *RaftBalloon) ID() string {
 	return b.id
 }
 
 // LeaderID returns the node ID of the Raft leader. Returns a
 // blank string if there is no leader, or an error.
-func (b RaftBalloon) LeaderID() (string, error) {
+func (b *RaftBalloon) LeaderID() (string, error) {
 	addr := b.LeaderAddr()
 	configFuture := b.raft.api.GetConfiguration()
 	if err := configFuture.Error(); err != nil {
@@ -336,7 +336,7 @@ func (b RaftBalloon) LeaderID() (string, error) {
 }
 
 // Nodes returns the slice of nodes in the cluster, sorted by ID ascending.
-func (b RaftBalloon) Nodes() ([]raft.Server, error) {
+func (b *RaftBalloon) Nodes() ([]raft.Server, error) {
 	f := b.raft.api.GetConfiguration()
 	if f.Error() != nil {
 		return nil, f.Error()
@@ -404,10 +404,10 @@ func (b *RaftBalloon) Add(event []byte) (*balloon.Commitment, error) {
 	return resp.(*fsmAddResponse).commitment, nil
 }
 
-func (b RaftBalloon) QueryMembership(event []byte, version uint64) (*balloon.MembershipProof, error) {
+func (b *RaftBalloon) QueryMembership(event []byte, version uint64) (*balloon.MembershipProof, error) {
 	return b.fsm.QueryMembership(event, version)
 }
 
-func (b RaftBalloon) QueryConsistency(start, end uint64) (*balloon.IncrementalProof, error) {
+func (b *RaftBalloon) QueryConsistency(start, end uint64) (*balloon.IncrementalProof, error) {
 	return b.fsm.QueryConsistency(start, end)
 }

--- a/tests/riot.go
+++ b/tests/riot.go
@@ -116,11 +116,12 @@ func Attacker(goRoutineId int, c *Config, f func(j int, c *Config) ([]byte, erro
 
 		// Set Api-Key header
 		req.Header.Set("Api-Key", c.apiKey)
-		res, err := c.req.client.Do(req)
-		defer res.Body.Close()
+		res, _ := c.req.client.Do(req)
 		if err != nil {
 			log.Fatalf("Unable to perform request: %v", err)
 		}
+		defer res.Body.Close()
+
 		if res.StatusCode != c.req.expectedStatusCode {
 			log.Fatalf("Server error: %v", err)
 		}
@@ -167,10 +168,11 @@ func getVersion(eventTemplate string) uint64 {
 	// TODO: remove pepe and pass a config var
 	req.Header.Set("Api-Key", "pepe")
 	res, err := client.Do(req)
-	defer res.Body.Close()
 	if err != nil {
 		log.Fatalf("Unable to perform request: %v", err)
 	}
+	defer res.Body.Close()
+
 	if res.StatusCode != 201 {
 		log.Fatalf("Server error: %v", err)
 	}


### PR DESCRIPTION
`go vet -composites=false ./...` was raising this kind of errors `balloon/history/tree.go:39: literal copies lock value from lock: sync.RWMutex`

digging around internet I found https://medium.com/golangspec/detect-locks-passed-by-value-in-go-efb4ac9a3f2b that explains why it shouldn't we doing it.

