### PR TITLE
TLS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ coverage.txt
 *terraform.tfstate*
 *.tfstate*
 *terraform.tfvars*
+.golangci.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,9 @@ notifications:
 
 before_script:
   - ssh-keygen -t ed25519 -f $HOME/.ssh/id_ed25519 -P ''
-  - openssl genrsa -out $HOME/.ssh/server.key 2048
-  - openssl req -new -x509 -sha256 -key $HOME/.ssh/server.key -out $HOME/.ssh/server.crt -days 3650
+  - openssl req -newkey rsa:2048 -nodes -days 3650 -x509 -keyout $HOME/.ssh/ca.key -out $HOME/.ssh/ca.crt -subj "/CN=*"
+  - openssl req -newkey rsa:2048 -nodes -keyout $HOME/.ssh/server.key -out $HOME/.ssh/server.csr -subj "/C=GB/ST=London/L=London/O=Global Security/OU=IT Department/CN=*"
+  - openssl x509 -req -days 365 -sha256 -in $HOME/.ssh/server.csr -CA $HOME/.ssh/ca.crt -CAkey $HOME/.ssh/ca.key -CAcreateserial -out $HOME/.ssh/server.crt -extfile <(echo subjectAltName = IP:127.0.0.1)
   - go mod download
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ notifications:
 
 before_script:
   - ssh-keygen -t ed25519 -f $HOME/.ssh/id_ed25519 -P ''
+  - openssl genrsa -out $HOME/.ssh/server.key 2048
+  - openssl req -new -x509 -sha256 -key $HOME/.ssh/server.key -out $HOME/.ssh/server.crt -days 3650
   - go mod download
 
 script:

--- a/api/apihttp/apihttp.go
+++ b/api/apihttp/apihttp.go
@@ -344,3 +344,13 @@ func LogHandler(handle http.Handler) http.HandlerFunc {
 		}
 	}
 }
+
+// STSHandler adds TLS Header to the handlers
+func STSHandler(handle http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, request *http.Request) {
+		w.Header().Add(
+			"Strict-Transport-Security",
+			"max-age=63072000; includeSubDomains",
+		)
+	}
+}

--- a/api/apihttp/apihttp.go
+++ b/api/apihttp/apihttp.go
@@ -105,6 +105,7 @@ func Add(balloon raftwal.RaftBalloonApi) http.HandlerFunc {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+
 		snapshot := &protocol.Snapshot{
 			response.HistoryDigest,
 			response.HyperDigest,
@@ -120,6 +121,7 @@ func Add(balloon raftwal.RaftBalloonApi) http.HandlerFunc {
 
 		w.WriteHeader(http.StatusCreated)
 		w.Write(out)
+
 		return
 
 	}
@@ -342,15 +344,5 @@ func LogHandler(handle http.Handler) http.HandlerFunc {
 		if writer.status >= 400 {
 			log.Infof("Bad Request: %d %+v", latency, request)
 		}
-	}
-}
-
-// STSHandler adds TLS Header to the handlers
-func STSHandler(handle http.Handler) http.HandlerFunc {
-	return func(w http.ResponseWriter, request *http.Request) {
-		w.Header().Add(
-			"Strict-Transport-Security",
-			"max-age=63072000; includeSubDomains",
-		)
 	}
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 var (
-	client *HttpClient
+	client *HTTPClient
 	mux    *http.ServeMux
 	server *httptest.Server
 )
@@ -42,7 +42,11 @@ func init() {
 func setup() func() {
 	mux = http.NewServeMux()
 	server = httptest.NewServer(mux)
-	client = NewHttpClient(server.URL, "my-awesome-api-key")
+	client = NewHTTPClient(&Config{
+		Endpoint:  server.URL,
+		APIKey:    "my-awesome-api-key",
+		EnableTLS: false,
+	})
 	return func() {
 		server.Close()
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -42,10 +42,10 @@ func init() {
 func setup() func() {
 	mux = http.NewServeMux()
 	server = httptest.NewServer(mux)
-	client = NewHTTPClient(&Config{
+	client = NewHTTPClient(Config{
 		Endpoint:  server.URL,
 		APIKey:    "my-awesome-api-key",
-		EnableTLS: false,
+		Insecure: false,
 	})
 	return func() {
 		server.Close()

--- a/client/config.go
+++ b/client/config.go
@@ -17,20 +17,20 @@
 package client
 
 type Config struct {
-	// Server host:port to consult
+	// Server host:port to consult.
 	Endpoint string
 
-	// ApiKey to query the server endpoint
+	// ApiKey to query the server endpoint.
 	APIKey string
 
-	// Enable TLS service
-	EnableTLS bool
+	// Enable self-signed certificates, allowing MiTM vector attacks.
+	Insecure bool
 }
 
 func DefaultConfig() *Config {
 	return &Config{
-		Endpoint:  "localhost:8080",
-		APIKey:    "my-key",
-		EnableTLS: true,
+		Endpoint: "localhost:8080",
+		APIKey:   "my-key",
+		Insecure: true,
 	}
 }

--- a/client/config.go
+++ b/client/config.go
@@ -14,23 +14,23 @@
    limitations under the License.
 */
 
-package cmd
+package client
 
-import (
-	"github.com/bbva/qed/client"
-	"github.com/bbva/qed/gossip"
-)
+type Config struct {
+	// Server host:port to consult
+	Endpoint string
 
-type cmdContext struct {
-	apiKey, logLevel string
+	// ApiKey to query the server endpoint
+	APIKey string
+
+	// Enable TLS service
+	EnableTLS bool
 }
 
-type clientContext struct {
-	endpoint   string
-	disableTLS bool
-	client     *client.HTTPClient
-}
-
-type agentContext struct {
-	config *gossip.Config
+func DefaultConfig() *Config {
+	return &Config{
+		Endpoint:  "localhost:8080",
+		APIKey:    "my-key",
+		EnableTLS: true,
+	}
 }

--- a/cmd/agent_auditor.go
+++ b/cmd/agent_auditor.go
@@ -22,50 +22,44 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newAgentAuditorCommand(ctx *agentContext) *cobra.Command {
+func newAgentAuditorCommand(ctx *cmdContext, config *gossip.Config) *cobra.Command {
 
-	var qedUrls, pubUrls []string
+	auditorConfig := auditor.DefaultConfig()
 
 	cmd := &cobra.Command{
 		Use:   "auditor",
 		Short: "Start a QED auditor",
-		Long: `Start a QED auditor that reacts to snapshot batches 
-		propagated by QED servers and periodically executes membership 
-		queries to verify the inclusion of events`,
+		Long:  `Start a QED auditor that reacts to snapshot batches propagated by QED servers and periodically executes membership queries to verify the inclusion of events`,
 		Run: func(cmd *cobra.Command, args []string) {
 
-			log.SetLogger("QedAuditor", logLevel)
+			log.SetLogger("QedAuditor", ctx.logLevel)
 
-			agentConfig := ctx.config
-			agentConfig.Role = member.Auditor
-			auditorConfig := auditor.DefaultConfig()
-			auditorConfig.APIKey = apiKey
-			auditorConfig.QEDUrls = qedUrls
-			auditorConfig.PubUrls = pubUrls
+			config.Role = member.Auditor
+			auditorConfig.APIKey = ctx.apiKey
 
 			auditor, err := auditor.NewAuditor(*auditorConfig)
 			if err != nil {
 				log.Fatalf("Failed to start the QED monitor: %v", err)
 			}
 
-			agent, err := gossip.NewAgent(agentConfig, []gossip.Processor{auditor})
+			agent, err := gossip.NewAgent(config, []gossip.Processor{auditor})
 			if err != nil {
 				log.Fatalf("Failed to start the QED auditor: %v", err)
 			}
 
-			contacted, err := agent.Join(agentConfig.StartJoin)
+			contacted, err := agent.Join(config.StartJoin)
 			if err != nil {
 				log.Fatalf("Failed to join the cluster: %v", err)
 			}
-			log.Debugf("Number of nodes contacted: %d (%v)", contacted, agentConfig.StartJoin)
+			log.Debugf("Number of nodes contacted: %d (%v)", contacted, config.StartJoin)
 
 			defer agent.Shutdown()
 			util.AwaitTermSignal(agent.Leave)
 		},
 	}
 
-	cmd.Flags().StringSliceVarP(&qedUrls, "qedUrls", "", []string{}, "Comma-delimited list of QED servers ([host]:port), through which an auditor can make queries")
-	cmd.Flags().StringSliceVarP(&pubUrls, "pubUrls", "", []string{}, "Comma-delimited list of QED servers ([host]:port), through which an auditor can make queries")
+	cmd.Flags().StringSliceVarP(&auditorConfig.QEDUrls, "qedUrls", "", []string{}, "Comma-delimited list of QED servers ([host]:port), through which an auditor can make queries")
+	cmd.Flags().StringSliceVarP(&auditorConfig.PubUrls, "pubUrls", "", []string{}, "Comma-delimited list of QED servers ([host]:port), through which an auditor can make queries")
 	cmd.MarkFlagRequired("qedUrls")
 	cmd.MarkFlagRequired("pubUrls")
 

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -22,34 +22,32 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var clientEndpoint string
+func newClientCommand(ctx *cmdContext) *cobra.Command {
+	var endpoint string
+	var disableTLS bool
 
-func newClientCommand() *cobra.Command {
-
-	ctx := newClientContext()
+	client := client.NewHTTPClient(&client.Config{
+		Endpoint:  endpoint,
+		APIKey:    ctx.apiKey,
+		EnableTLS: !disableTLS,
+	})
 
 	cmd := &cobra.Command{
 		Use:   "client",
 		Short: "Client mode for qed",
 		Long:  `Client process for emitting events to a qed server`,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			log.SetLogger("QedClient", logLevel)
-			ctx.client = client.NewHttpClient(clientEndpoint, apiKey)
+			log.SetLogger("QedClient", ctx.logLevel)
 		},
 		TraverseChildren: true,
 	}
 
-	cmd.PersistentFlags().StringVarP(
-		&clientEndpoint,
-		"endpoint",
-		"e",
-		"http://localhost:8080",
-		"Endpoint for REST requests on (host:port)",
-	)
+	cmd.PersistentFlags().StringVarP(&endpoint, "endpoint", "e", "localhost:8080", "Endpoint for REST requests on (host:port)")
+	cmd.PersistentFlags().BoolVar(&disableTLS, "insecure", false, "Disable TLS transport")
 
-	cmd.AddCommand(newAddCommand(ctx))
-	cmd.AddCommand(newMembershipCommand(ctx))
-	cmd.AddCommand(newIncrementalCommand(ctx))
+	cmd.AddCommand(newAddCommand(client))
+	cmd.AddCommand(newMembershipCommand(client))
+	cmd.AddCommand(newIncrementalCommand(client))
 
 	return cmd
 }

--- a/cmd/client_add.go
+++ b/cmd/client_add.go
@@ -19,11 +19,10 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/bbva/qed/client"
 	"github.com/bbva/qed/log"
 )
 
-func newAddCommand(client *client.HTTPClient) *cobra.Command {
+func newAddCommand(ctx *clientContext) *cobra.Command {
 
 	var key, value string
 
@@ -34,7 +33,7 @@ func newAddCommand(client *client.HTTPClient) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Infof("Adding key [ %s ] with value [ %s ]\n", key, value)
 
-			snapshot, err := client.Add(key)
+			snapshot, err := ctx.client.Add(key)
 			if err != nil {
 				return err
 			}

--- a/cmd/client_add.go
+++ b/cmd/client_add.go
@@ -19,10 +19,11 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/bbva/qed/client"
 	"github.com/bbva/qed/log"
 )
 
-func newAddCommand(ctx *clientContext) *cobra.Command {
+func newAddCommand(client *client.HTTPClient) *cobra.Command {
 
 	var key, value string
 
@@ -33,7 +34,7 @@ func newAddCommand(ctx *clientContext) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Infof("Adding key [ %s ] with value [ %s ]\n", key, value)
 
-			snapshot, err := ctx.client.Add(key)
+			snapshot, err := client.Add(key)
 			if err != nil {
 				return err
 			}

--- a/cmd/client_incremental.go
+++ b/cmd/client_incremental.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"encoding/hex"
 
-	"github.com/bbva/qed/client"
 	"github.com/bbva/qed/hashing"
 	"github.com/bbva/qed/protocol"
 
@@ -28,7 +27,7 @@ import (
 	"github.com/bbva/qed/log"
 )
 
-func newIncrementalCommand(client *client.HTTPClient) *cobra.Command {
+func newIncrementalCommand(ctx *clientContext) *cobra.Command {
 
 	var start, end uint64
 	var verify bool
@@ -53,7 +52,7 @@ func newIncrementalCommand(client *client.HTTPClient) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Infof("Querying incremental between versions [ %d ] and [ %d ]\n", start, end)
 
-			proof, err := client.Incremental(start, end)
+			proof, err := ctx.client.Incremental(start, end)
 			if err != nil {
 				return err
 			}
@@ -68,7 +67,7 @@ func newIncrementalCommand(client *client.HTTPClient) *cobra.Command {
 
 				log.Infof("Verifying with snapshots: \n\tStartDigest: %s\n\tEndDigest: %s\n",
 					startDigest, endDigest)
-				if client.VerifyIncremental(proof, startSnapshot, endSnapshot, hashing.NewSha256Hasher()) {
+				if ctx.client.VerifyIncremental(proof, startSnapshot, endSnapshot, hashing.NewSha256Hasher()) {
 					log.Info("Verify: OK")
 				} else {
 					log.Info("Verify: KO")

--- a/cmd/client_incremental.go
+++ b/cmd/client_incremental.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"encoding/hex"
 
+	"github.com/bbva/qed/client"
 	"github.com/bbva/qed/hashing"
 	"github.com/bbva/qed/protocol"
 
@@ -27,7 +28,7 @@ import (
 	"github.com/bbva/qed/log"
 )
 
-func newIncrementalCommand(ctx *clientContext) *cobra.Command {
+func newIncrementalCommand(client *client.HTTPClient) *cobra.Command {
 
 	var start, end uint64
 	var verify bool
@@ -52,7 +53,7 @@ func newIncrementalCommand(ctx *clientContext) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Infof("Querying incremental between versions [ %d ] and [ %d ]\n", start, end)
 
-			proof, err := ctx.client.Incremental(start, end)
+			proof, err := client.Incremental(start, end)
 			if err != nil {
 				return err
 			}
@@ -67,7 +68,7 @@ func newIncrementalCommand(ctx *clientContext) *cobra.Command {
 
 				log.Infof("Verifying with snapshots: \n\tStartDigest: %s\n\tEndDigest: %s\n",
 					startDigest, endDigest)
-				if ctx.client.VerifyIncremental(proof, startSnapshot, endSnapshot, hashing.NewSha256Hasher()) {
+				if client.VerifyIncremental(proof, startSnapshot, endSnapshot, hashing.NewSha256Hasher()) {
 					log.Info("Verify: OK")
 				} else {
 					log.Info("Verify: KO")
@@ -83,7 +84,6 @@ func newIncrementalCommand(ctx *clientContext) *cobra.Command {
 	cmd.Flags().BoolVar(&verify, "verify", false, "Do verify received proof")
 	cmd.Flags().StringVar(&startDigest, "startDigest", "", "Start digest of the history tree")
 	cmd.Flags().StringVar(&endDigest, "endDigest", "", "End digest of the history tree")
-
 	cmd.MarkFlagRequired("start")
 	cmd.MarkFlagRequired("end")
 

--- a/cmd/client_membership.go
+++ b/cmd/client_membership.go
@@ -19,16 +19,14 @@ package cmd
 import (
 	"encoding/hex"
 
-	"github.com/bbva/qed/client"
-	"github.com/bbva/qed/hashing"
-	"github.com/bbva/qed/protocol"
-
 	"github.com/spf13/cobra"
 
+	"github.com/bbva/qed/hashing"
 	"github.com/bbva/qed/log"
+	"github.com/bbva/qed/protocol"
 )
 
-func newMembershipCommand(client *client.HTTPClient) *cobra.Command {
+func newMembershipCommand(ctx *clientContext) *cobra.Command {
 
 	hasherF := hashing.NewSha256Hasher
 	var version uint64
@@ -68,7 +66,7 @@ func newMembershipCommand(client *client.HTTPClient) *cobra.Command {
 				digest, _ = hex.DecodeString(eventDigest)
 			}
 
-			membershipResult, err = client.MembershipDigest(digest, version)
+			membershipResult, err = ctx.client.MembershipDigest(digest, version)
 			if err != nil {
 				return err
 			}
@@ -99,7 +97,7 @@ func newMembershipCommand(client *client.HTTPClient) *cobra.Command {
 				log.Infof("Verifying with Snapshot: \n\tEventDigest:%x\n\tHyperDigest: %s\n\tHistoryDigest: %s\n\tVersion: %d\n",
 					digest, hyperDigest, historyDigest, version)
 
-				if client.DigestVerify(membershipResult, snapshot, hasherF) {
+				if ctx.client.DigestVerify(membershipResult, snapshot, hasherF) {
 					log.Info("Verify: OK")
 				} else {
 					log.Info("Verify: KO")

--- a/cmd/client_membership.go
+++ b/cmd/client_membership.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"encoding/hex"
 
+	"github.com/bbva/qed/client"
 	"github.com/bbva/qed/hashing"
 	"github.com/bbva/qed/protocol"
 
@@ -27,7 +28,7 @@ import (
 	"github.com/bbva/qed/log"
 )
 
-func newMembershipCommand(ctx *clientContext) *cobra.Command {
+func newMembershipCommand(client *client.HTTPClient) *cobra.Command {
 
 	hasherF := hashing.NewSha256Hasher
 	var version uint64
@@ -67,7 +68,7 @@ func newMembershipCommand(ctx *clientContext) *cobra.Command {
 				digest, _ = hex.DecodeString(eventDigest)
 			}
 
-			membershipResult, err = ctx.client.MembershipDigest(digest, version)
+			membershipResult, err = client.MembershipDigest(digest, version)
 			if err != nil {
 				return err
 			}
@@ -98,7 +99,7 @@ func newMembershipCommand(ctx *clientContext) *cobra.Command {
 				log.Infof("Verifying with Snapshot: \n\tEventDigest:%x\n\tHyperDigest: %s\n\tHistoryDigest: %s\n\tVersion: %d\n",
 					digest, hyperDigest, historyDigest, version)
 
-				if ctx.client.DigestVerify(membershipResult, snapshot, hasherF) {
+				if client.DigestVerify(membershipResult, snapshot, hasherF) {
 					log.Info("Verify: OK")
 				} else {
 					log.Info("Verify: KO")

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -26,9 +26,9 @@ type cmdContext struct {
 }
 
 type clientContext struct {
-	endpoint   string
-	disableTLS bool
-	client     *client.HTTPClient
+	endpoint string
+	insecure bool
+	client   *client.HTTPClient
 }
 
 type agentContext struct {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,45 +19,25 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-
-	"github.com/bbva/qed/log"
-)
-
-var (
-	apiKey, logLevel string
 )
 
 // NewRootCommand is the main Parser for the qed cli.
 func NewRootCommand() *cobra.Command {
+	ctx := &cmdContext{}
 
 	cmd := &cobra.Command{
-		Use:       "qed",
-		Short:     "QED is a client for the verifiable log server",
-		Long:      `blah blah`,
-		ValidArgs: []string{"add", "verify"},
-		Args: func(cmd *cobra.Command, args []string) error {
-			err1 := cobra.MinimumNArgs(1)(cmd, args)
-			if err1 != nil {
-				return err1
-			}
-			err2 := cobra.OnlyValidArgs(cmd, args)
-			return err2
-		},
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-
-			log.SetLogger("QedServer", logLevel)
-
-		},
+		Use:              "qed",
+		Short:            "QED is a client for the verifiable log server",
 		TraverseChildren: true,
 	}
 
-	cmd.PersistentFlags().StringVarP(&logLevel, "log", "l", "error", "Choose between log levels: silent, error, info and debug")
-	cmd.PersistentFlags().StringVarP(&apiKey, "apikey", "k", "", "Server api key")
+	cmd.PersistentFlags().StringVarP(&ctx.logLevel, "log", "l", "error", "Choose between log levels: silent, error, info and debug")
+	cmd.PersistentFlags().StringVarP(&ctx.apiKey, "apikey", "k", "", "Server api key")
 	cmd.MarkPersistentFlagRequired("apikey")
 
-	cmd.AddCommand(newStartCommand())
-	cmd.AddCommand(newClientCommand())
-	cmd.AddCommand(newAgentCommand())
+	cmd.AddCommand(newStartCommand(ctx))
+	cmd.AddCommand(newClientCommand(ctx))
+	cmd.AddCommand(newAgentCommand(ctx))
 
 	return cmd
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -61,7 +61,7 @@ func newStartCommand() *cobra.Command {
 
 	hostname, _ := os.Hostname()
 	cmd.Flags().StringVar(&conf.NodeID, "node-id", hostname, "Unique name for node. If not set, fallback to hostname")
-	cmd.Flags().StringVar(&conf.HttpAddr, "http-addr", ":8080", "Endpoint for REST requests on (host:port)")
+	cmd.Flags().StringVar(&conf.TLSAddr, "https-addr", ":443", "Endpoint for REST requests on (host:port)")
 	cmd.Flags().StringVar(&conf.RaftAddr, "raft-addr", ":9000", "Raft bind address (host:port)")
 	cmd.Flags().StringVar(&conf.MgmtAddr, "mgmt-addr", ":8090", "Management endpoint bind address (host:port)")
 	cmd.Flags().StringSliceVar(&conf.RaftJoinAddr, "join-addr", []string{}, "Raft: Comma-delimited list of nodes ([host]:port), through which a cluster can be joined")

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -27,9 +27,8 @@ import (
 	"github.com/bbva/qed/server"
 )
 
-func newStartCommand() *cobra.Command {
+func newStartCommand(ctx *cmdContext) *cobra.Command {
 	const defaultKeyPath = "~/.ssh/id_ed25519"
-
 	var disableTLS bool
 	conf := server.DefaultConfig()
 
@@ -38,7 +37,9 @@ func newStartCommand() *cobra.Command {
 		Short: "Start the server for the verifiable log QED",
 		Long:  ``,
 		// Args:  cobra.NoArgs(),
-
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			log.SetLogger("QedServer", ctx.logLevel)
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			conf.EnableTLS = !disableTLS
 
@@ -48,7 +49,6 @@ func newStartCommand() *cobra.Command {
 			}
 
 			srv, err := server.NewServer(conf)
-
 			if err != nil {
 				log.Fatalf("Can't start QED server: %v", err)
 			}
@@ -73,11 +73,11 @@ func newStartCommand() *cobra.Command {
 	cmd.Flags().StringVar(&conf.RaftPath, "raftpath", "/var/tmp/qed/raft", "Set raft storage path")
 	cmd.Flags().StringVarP(&conf.PrivateKeyPath, "keypath", "y", defaultKeyPath, "Path to the ed25519 key file")
 	cmd.Flags().BoolVarP(&conf.EnableProfiling, "profiling", "f", false, "Allow a pprof url (localhost:6060) for profiling purposes")
-	cmd.Flags().BoolVar(&disableTLS, "insecure", "", false, "Disable TLS service")
+	cmd.Flags().BoolVar(&disableTLS, "insecure", false, "Disable TLS service")
 
 	// INFO: testing purposes
 	cmd.Flags().BoolVar(&conf.EnableTampering, "tampering", false, "Allow tampering api for proof demostrations")
-	cmd.Flags().MarkHidden("tampering")
+	cmd.Flags().MarkHidden("tampering") // nolint: errcheck
 
 	return cmd
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -30,6 +30,7 @@ import (
 func newStartCommand() *cobra.Command {
 	const defaultKeyPath = "~/.ssh/id_ed25519"
 
+	var disableTLS bool
 	conf := server.DefaultConfig()
 
 	cmd := &cobra.Command{
@@ -39,6 +40,7 @@ func newStartCommand() *cobra.Command {
 		// Args:  cobra.NoArgs(),
 
 		Run: func(cmd *cobra.Command, args []string) {
+			conf.EnableTLS = !disableTLS
 
 			if conf.PrivateKeyPath == defaultKeyPath {
 				usr, _ := user.Current()
@@ -61,7 +63,7 @@ func newStartCommand() *cobra.Command {
 
 	hostname, _ := os.Hostname()
 	cmd.Flags().StringVar(&conf.NodeID, "node-id", hostname, "Unique name for node. If not set, fallback to hostname")
-	cmd.Flags().StringVar(&conf.TLSAddr, "https-addr", ":443", "Endpoint for REST requests on (host:port)")
+	cmd.Flags().StringVar(&conf.HTTPAddr, "http-addr", ":8080", "Endpoint for REST requests on (host:port)")
 	cmd.Flags().StringVar(&conf.RaftAddr, "raft-addr", ":9000", "Raft bind address (host:port)")
 	cmd.Flags().StringVar(&conf.MgmtAddr, "mgmt-addr", ":8090", "Management endpoint bind address (host:port)")
 	cmd.Flags().StringSliceVar(&conf.RaftJoinAddr, "join-addr", []string{}, "Raft: Comma-delimited list of nodes ([host]:port), through which a cluster can be joined")
@@ -71,6 +73,7 @@ func newStartCommand() *cobra.Command {
 	cmd.Flags().StringVar(&conf.RaftPath, "raftpath", "/var/tmp/qed/raft", "Set raft storage path")
 	cmd.Flags().StringVarP(&conf.PrivateKeyPath, "keypath", "y", defaultKeyPath, "Path to the ed25519 key file")
 	cmd.Flags().BoolVarP(&conf.EnableProfiling, "profiling", "f", false, "Allow a pprof url (localhost:6060) for profiling purposes")
+	cmd.Flags().BoolVar(&disableTLS, "insecure", "", false, "Disable TLS service")
 
 	// INFO: testing purposes
 	cmd.Flags().BoolVar(&conf.EnableTampering, "tampering", false, "Allow tampering api for proof demostrations")

--- a/docs/development.md
+++ b/docs/development.md
@@ -3,6 +3,19 @@
 We use the [Go](https://golang.org) programming language and set up the
 environment as described in its [documentation](https://golang.org/doc/code.html)
 
+## Self-signed certificate
+
+```
+cd ~/.ssh/
+
+# Generate private key (.key)
+openssl genrsa -out server.key 2048
+
+
+# Generation of self-signed(x509) public key (PEM-encodings .pem|.crt) based on the private (.key)
+openssl req -new -x509 -sha256 -key server.key -out server.crt -days 3650
+```
+
 ## Useful commands
 
 - Go [documentation server](http://localhost:6061/pkg/github.com/bbva/qed/)

--- a/gossip/auditor/auditor.go
+++ b/gossip/auditor/auditor.go
@@ -46,7 +46,7 @@ func DefaultConfig() *Config {
 }
 
 type Auditor struct {
-	qed  *client.HttpClient
+	qed  *client.HTTPClient
 	conf Config
 
 	taskCh          chan Task
@@ -56,7 +56,11 @@ type Auditor struct {
 
 func NewAuditor(conf Config) (*Auditor, error) {
 	auditor := Auditor{
-		qed:    client.NewHttpClient(conf.QEDUrls[0], conf.APIKey),
+		qed: client.NewHTTPClient(&client.Config{
+			Endpoint:  conf.QEDUrls[0],
+			APIKey:    conf.APIKey,
+			EnableTLS: false,
+		}),
 		conf:   conf,
 		taskCh: make(chan Task, 100),
 		quitCh: make(chan bool),
@@ -125,7 +129,7 @@ func (t MembershipTask) getSnapshot(version uint64) (*protocol.SignedSnapshot, e
 }
 
 type MembershipTask struct {
-	qed    *client.HttpClient
+	qed    *client.HTTPClient
 	pubUrl string
 	taskCh chan Task
 	s      protocol.SignedSnapshot

--- a/gossip/auditor/auditor.go
+++ b/gossip/auditor/auditor.go
@@ -56,10 +56,10 @@ type Auditor struct {
 
 func NewAuditor(conf Config) (*Auditor, error) {
 	auditor := Auditor{
-		qed: client.NewHTTPClient(&client.Config{
+		qed: client.NewHTTPClient(client.Config{
 			Endpoint:  conf.QEDUrls[0],
 			APIKey:    conf.APIKey,
-			EnableTLS: false,
+			Insecure: false,
 		}),
 		conf:   conf,
 		taskCh: make(chan Task, 100),

--- a/gossip/monitor/monitor.go
+++ b/gossip/monitor/monitor.go
@@ -57,10 +57,10 @@ type Monitor struct {
 func NewMonitor(conf Config) (*Monitor, error) {
 
 	monitor := Monitor{
-		client: client.NewHTTPClient(&client.Config{
+		client: client.NewHTTPClient(client.Config{
 			Endpoint:  conf.QedUrls[0],
 			APIKey:    conf.APIKey,
-			EnableTLS: false,
+			Insecure: false,
 		}),
 		conf:   conf,
 		taskCh: make(chan QueryTask, 100),

--- a/gossip/monitor/monitor.go
+++ b/gossip/monitor/monitor.go
@@ -46,7 +46,7 @@ func DefaultConfig() *Config {
 }
 
 type Monitor struct {
-	client *client.HttpClient
+	client *client.HTTPClient
 	conf   Config
 
 	taskCh          chan QueryTask
@@ -55,9 +55,13 @@ type Monitor struct {
 }
 
 func NewMonitor(conf Config) (*Monitor, error) {
-	client := client.NewHttpClient(conf.QedUrls[0], conf.APIKey)
+
 	monitor := Monitor{
-		client: client,
+		client: client.NewHTTPClient(&client.Config{
+			Endpoint:  conf.QedUrls[0],
+			APIKey:    conf.APIKey,
+			EnableTLS: false,
+		}),
 		conf:   conf,
 		taskCh: make(chan QueryTask, 100),
 		quitCh: make(chan bool),

--- a/log/log.go
+++ b/log/log.go
@@ -66,11 +66,11 @@ var (
 
 	// Fatal is the public log function to write to stdOut and stop execution
 	// Same as Error.
-	Fatal func(...interface{}) = Error
+	Fatal = Error
 
 	// Panic is the public log function to write to stdOut and stop execution
 	// Same as Error.
-	Panic func(...interface{}) = Error
+	Panic = Error
 )
 
 // Errorf is the public log function with params to write to stdOut and stop
@@ -83,11 +83,11 @@ var (
 
 	// Fatalf is the public log function with params to write to stdOut and
 	// stop execution. Same as Errorf
-	Fatalf func(string, ...interface{}) = Errorf
+	Fatalf = Errorf
 
 	// Panicf is the public log function with params to write to stdOut and
 	// stop execution. Same as Errorf
-	Panicf func(string, ...interface{}) = Errorf
+	Panicf = Errorf
 )
 
 // Info is the public log function to write information relative to the usage

--- a/server/config.go
+++ b/server/config.go
@@ -17,8 +17,10 @@
 package server
 
 import (
+	"fmt"
 	"net"
 	"os"
+	"os/user"
 	"path/filepath"
 )
 
@@ -27,8 +29,8 @@ type Config struct {
 	// gossip clusters. If not set, fallback to hostname.
 	NodeID string
 
-	// HTTP server bind address/port.
-	HttpAddr string
+	// TLS server bind address/port.
+	TLSAddr string
 
 	// Raft communication bind address/port.
 	RaftAddr string
@@ -61,23 +63,35 @@ type Config struct {
 
 	// Enables tampering endpoint.
 	EnableTampering bool
+
+	// TLS server cerificate
+	SSLCertificate string
+
+	// TLS server cerificate key
+	SSLCertificateKey string
 }
 
 func DefaultConfig() *Config {
 	hostname, _ := os.Hostname()
 	currentDir := getCurrentDir()
+
+	usr, _ := user.Current()
+	homeDir := usr.HomeDir
+
 	return &Config{
-		NodeID:          hostname,
-		HttpAddr:        "127.0.0.1:8080",
-		RaftAddr:        "127.0.0.1:9000",
-		MgmtAddr:        "127.0.0.1:8090",
-		RaftJoinAddr:    []string{},
-		GossipAddr:      "127.0.0.1:9100",
-		GossipJoinAddr:  []string{},
-		DBPath:          currentDir + "/data",
-		RaftPath:        currentDir + "/raft",
-		EnableProfiling: false,
-		EnableTampering: false,
+		NodeID:            hostname,
+		TLSAddr:           "127.0.0.1:443",
+		RaftAddr:          "127.0.0.1:9000",
+		MgmtAddr:          "127.0.0.1:8090",
+		RaftJoinAddr:      []string{},
+		GossipAddr:        "127.0.0.1:9100",
+		GossipJoinAddr:    []string{},
+		DBPath:            currentDir + "/data",
+		RaftPath:          currentDir + "/raft",
+		EnableProfiling:   false,
+		EnableTampering:   false,
+		SSLCertificate:    fmt.Sprintf("%s/.ssh/server.crt", homeDir),
+		SSLCertificateKey: fmt.Sprintf("%s/.ssh/server.key", homeDir),
 	}
 }
 

--- a/server/config.go
+++ b/server/config.go
@@ -30,7 +30,7 @@ type Config struct {
 	NodeID string
 
 	// TLS server bind address/port.
-	TLSAddr string
+	HTTPAddr string
 
 	// Raft communication bind address/port.
 	RaftAddr string
@@ -64,6 +64,9 @@ type Config struct {
 	// Enables tampering endpoint.
 	EnableTampering bool
 
+	// Enable TLS service
+	EnableTLS bool
+
 	// TLS server cerificate
 	SSLCertificate string
 
@@ -80,7 +83,7 @@ func DefaultConfig() *Config {
 
 	return &Config{
 		NodeID:            hostname,
-		TLSAddr:           "127.0.0.1:443",
+		HTTPAddr:          "127.0.0.1:8080",
 		RaftAddr:          "127.0.0.1:9000",
 		MgmtAddr:          "127.0.0.1:8090",
 		RaftJoinAddr:      []string{},
@@ -90,6 +93,7 @@ func DefaultConfig() *Config {
 		RaftPath:          currentDir + "/raft",
 		EnableProfiling:   false,
 		EnableTampering:   false,
+		EnableTLS:         true,
 		SSLCertificate:    fmt.Sprintf("%s/.ssh/server.crt", homeDir),
 		SSLCertificateKey: fmt.Sprintf("%s/.ssh/server.key", homeDir),
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -313,7 +313,7 @@ func newTLSServer(addr string, mux *http.ServeMux) *http.Server {
 
 	return &http.Server{
 		Addr:         addr,
-		Handler:      apihttp.STSHandler(apihttp.LogHandler(mux)),
+		Handler:      apihttp.LogHandler(mux),
 		TLSConfig:    cfg,
 		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0),
 	}

--- a/tests/e2e/add_verify_test.go
+++ b/tests/e2e/add_verify_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestAddVerify(t *testing.T) {
-	before, after := setupServer(0, "", t)
+	before, after := setupServer(0, "", false, t)
 	scenario, let := scope.Scope(t, before, after)
 
 	client := getClient(0)

--- a/tests/e2e/agents_test.go
+++ b/tests/e2e/agents_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func getSnapshot(version uint64) (*protocol.SignedSnapshot, error) {
-	resp, err := http.Get(fmt.Sprintf("%s/snapshot?v=%d", StoreUrl, version))
+	resp, err := http.Get(fmt.Sprintf("%s/snapshot?v=%d", StoreURL, version))
 	if err != nil {
 		return nil, fmt.Errorf("Error getting snapshot from the store: %v", err)
 	}
@@ -52,7 +52,7 @@ func getSnapshot(version uint64) (*protocol.SignedSnapshot, error) {
 }
 
 func getAlert() ([]byte, error) {
-	resp, err := http.Get(fmt.Sprintf("%s/alert", StoreUrl))
+	resp, err := http.Get(fmt.Sprintf("%s/alert", StoreURL))
 	if err != nil {
 		return []byte{}, fmt.Errorf("Error getting alert from alertStore: %v", err)
 	}

--- a/tests/e2e/agents_test.go
+++ b/tests/e2e/agents_test.go
@@ -66,7 +66,7 @@ func getAlert() ([]byte, error) {
 
 func TestAgents(t *testing.T) {
 	bStore, aStore := setupStore(t)
-	bServer, aServer := setupServer(0, "", t)
+	bServer, aServer := setupServer(0, "", false, t)
 	bAuditor, aAuditor := setupAuditor(0, t)
 	bMonitor, aMonitor := setupMonitor(0, t)
 	bPublisher, aPublisher := setupPublisher(0, t)

--- a/tests/e2e/cli_test.go
+++ b/tests/e2e/cli_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestCli(t *testing.T) {
-	before, after := setupServer(0, "", t)
+	before, after := setupServer(0, "", true, t)
 	scenario, let := scope.Scope(t, before, merge(after))
 
 	scenario("Add one event through cli and verify it", func() {
@@ -39,7 +39,7 @@ func TestCli(t *testing.T) {
 				"./../../main.go",
 				fmt.Sprintf("--apikey=%s", APIKey),
 				"client",
-				fmt.Sprintf("--endpoint=%s", QEDUrl),
+				fmt.Sprintf("--endpoint=%s", QEDTLS),
 				"add",
 				"--key='test event'",
 				"--value=2",
@@ -47,9 +47,7 @@ func TestCli(t *testing.T) {
 				"--insecure",
 			)
 
-			o, err := cmd.CombinedOutput()
-
-			fmt.Printf(">>>>> %s", o)
+			_, err := cmd.CombinedOutput()
 
 			assert.NoError(t, err, "Subprocess must not exit with status 1")
 		})
@@ -60,7 +58,7 @@ func TestCli(t *testing.T) {
 				"./../../main.go",
 				fmt.Sprintf("--apikey=%s", APIKey),
 				"client",
-				fmt.Sprintf("--endpoint=%s", QEDUrl),
+				fmt.Sprintf("--endpoint=%s", QEDTLS),
 				"membership",
 				"--hyperDigest=81ae2d8f6ecec9c5837d12a09e3b42a1c880b6c77f81ff1f85aef36dac4fdf6a",
 				"--historyDigest=0f5129eaf5dbfb1405ff072a04d716aaf4e4ba4247a3322c41582e970dbb7b00",
@@ -75,17 +73,15 @@ func TestCli(t *testing.T) {
 
 			assert.NoError(t, err, "Subprocess must not exit with status 1")
 			assert.True(t, strings.Contains(fmt.Sprintf("%s", stdoutStderr), "Verify: OK"), "Must verify with eventDigest")
-
 		})
 
 		let("verify event with eventDigest", func(t *testing.T) {
-
 			cmd := exec.Command("go",
 				"run",
 				"./../../main.go",
 				fmt.Sprintf("--apikey=%s", APIKey),
 				"client",
-				fmt.Sprintf("--endpoint=%s", QEDUrl),
+				fmt.Sprintf("--endpoint=%s", QEDTLS),
 				"membership",
 				"--hyperDigest=81ae2d8f6ecec9c5837d12a09e3b42a1c880b6c77f81ff1f85aef36dac4fdf6a",
 				"--historyDigest=0f5129eaf5dbfb1405ff072a04d716aaf4e4ba4247a3322c41582e970dbb7b00",
@@ -100,7 +96,6 @@ func TestCli(t *testing.T) {
 
 			assert.NoError(t, err, "Subprocess must not exit with status 1")
 			assert.True(t, strings.Contains(fmt.Sprintf("%s", stdoutStderr), "Verify: OK"), "Must verify with eventDigest")
-
 		})
 
 	})

--- a/tests/e2e/cli_test.go
+++ b/tests/e2e/cli_test.go
@@ -44,9 +44,12 @@ func TestCli(t *testing.T) {
 				"--key='test event'",
 				"--value=2",
 				"--log=info",
+				"--insecure",
 			)
 
-			_, err := cmd.CombinedOutput()
+			o, err := cmd.CombinedOutput()
+
+			fmt.Printf(">>>>> %s", o)
 
 			assert.NoError(t, err, "Subprocess must not exit with status 1")
 		})
@@ -65,6 +68,7 @@ func TestCli(t *testing.T) {
 				"--eventDigest=8694718de4363adf07ec3b4aff4c76589f60fe89a7715bee7c8b250e06493922",
 				"--log=info",
 				"--verify",
+				"--insecure",
 			)
 
 			stdoutStderr, err := cmd.CombinedOutput()
@@ -89,6 +93,7 @@ func TestCli(t *testing.T) {
 				"--key='test event'",
 				"--log=info",
 				"--verify",
+				"--insecure",
 			)
 
 			stdoutStderr, err := cmd.CombinedOutput()

--- a/tests/e2e/incremental_test.go
+++ b/tests/e2e/incremental_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestIncrementalConsistency(t *testing.T) {
-	before, after := setupServer(0, "", t)
+	before, after := setupServer(0, "", false, t)
 	scenario, let := scope.Scope(t, before, after)
 
 	client := getClient(0)

--- a/tests/e2e/test_service.go
+++ b/tests/e2e/test_service.go
@@ -104,7 +104,6 @@ func (s *statStore) Print() {
 	if err == nil {
 		fmt.Println(string(b))
 	}
-	return
 }
 
 func (s *Service) statHandler() func(http.ResponseWriter, *http.Request) {
@@ -159,6 +158,10 @@ func (s *Service) getSnapshotHandler() func(http.ResponseWriter, *http.Request) 
 				return
 			}
 			buf, err := b.Encode()
+			if err != nil {
+				fmt.Printf("ERROR: %v", err)
+			}
+
 			_, err = w.Write(buf)
 			if err != nil {
 				fmt.Printf("ERROR: %v", err)
@@ -208,8 +211,8 @@ func NewService() *Service {
 	var snaps snapStore
 	var alerts alertStore
 	var stats statStore
-	snaps.d = make(map[uint64]*protocol.SignedSnapshot, 0)
-	stats.batch = make(map[string][]int, 0)
+	snaps.d = make(map[uint64]*protocol.SignedSnapshot)
+	stats.batch = make(map[string][]int)
 	alerts.d = make([]string, 0)
 
 	return &Service{


### PR DESCRIPTION
Enable TLS configuration for QED servers. 
- Server is tls enabled by default (disabled by `--insecure` flag)
- Client honors CApools unless `--insecure` is called. 
- Client requires `http` - `https` urls to function correctly.