### PR TITLE
Add new cli command to generate ed25519 keypair

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.txt
 .golangci.yml
 config.yml
 deploy/aws/config_files/*
+deploy/aws/provision/config_files/*
 deploy/provision/config_files/*
 !deploy/aws/config_files/README.md
 deploy/aws/modules/*/data

--- a/cmd/client_membership.go
+++ b/cmd/client_membership.go
@@ -139,7 +139,7 @@ func runClientMembership(cmd *cobra.Command, args []string) error {
 				EventDigest:   digest,
 			}
 
-			fmt.Printf("\nVerifying event with: \n\n EventDigest: %x\n HyperDigest: %s\n HistoryDigest: %s\n Version: %d\n", digest, hdBytes, htdBytes, params.Version)
+			fmt.Printf("\nVerifying event with: \n\n EventDigest: %x\n HyperDigest: %x\n HistoryDigest: %x\n Version: %d\n", digest, hdBytes, htdBytes, params.Version)
 			ok, err = client.MembershipVerify(digest, proof, snapshot)
 		}
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -20,10 +20,20 @@ import (
 	"context"
 
 	"github.com/bbva/qed/log"
-	"github.com/bbva/qed/server"
 	"github.com/octago/sflags/gen/gpflag"
 	"github.com/spf13/cobra"
 )
+
+type GenerateConfig struct {
+	// Path to the private key file used to sign snapshots.
+	Path string
+}
+
+func GenerateDefaultConfig() *GenerateConfig {
+	return &GenerateConfig{
+		Path: "/var/tmp",
+	}
+}
 
 var generateCmd *cobra.Command = &cobra.Command{
 	Use:   "generate",
@@ -41,11 +51,11 @@ func init() {
 
 func generateConfig() context.Context {
 
-	conf := server.GenerateDefaultConfig()
+	conf := GenerateDefaultConfig()
 
 	err := gpflag.ParseTo(conf, generateCmd.PersistentFlags())
 	if err != nil {
 		log.Fatalf("err: %v", err)
 	}
-	return context.WithValue(Ctx, k("server.config"), conf)
+	return context.WithValue(Ctx, k("generate.config"), conf)
 }

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -1,0 +1,51 @@
+/*
+   Copyright 2018-2019 Banco Bilbao Vizcaya Argentaria, S.A.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+
+	"github.com/bbva/qed/log"
+	"github.com/bbva/qed/server"
+	"github.com/octago/sflags/gen/gpflag"
+	"github.com/spf13/cobra"
+)
+
+var generateCmd *cobra.Command = &cobra.Command{
+	Use:   "generate",
+	Short: "Generates configuration files,keys and cerificates for QED",
+	Long: `This command generates config files, keys and certificates
+required to run QED server.`,
+	TraverseChildren: true,
+}
+
+var generateCtx context.Context = generateConfig()
+
+func init() {
+	Root.AddCommand(generateCmd)
+}
+
+func generateConfig() context.Context {
+
+	conf := server.GenerateDefaultConfig()
+
+	err := gpflag.ParseTo(conf, generateCmd.PersistentFlags())
+	if err != nil {
+		log.Fatalf("err: %v", err)
+	}
+	return context.WithValue(Ctx, k("server.config"), conf)
+}

--- a/cmd/generate_keypair.go
+++ b/cmd/generate_keypair.go
@@ -1,0 +1,42 @@
+/*
+   Copyright 2018-2019 Banco Bilbao Vizcaya Argentaria, S.A.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/bbva/qed/crypto"
+	"github.com/spf13/cobra"
+
+	"github.com/bbva/qed/server"
+)
+
+var generateKeypair *cobra.Command = &cobra.Command{
+	Use:   "keypair",
+	Short: "Generate keypair",
+	Run:   runGenerateKeypair,
+}
+
+func init() {
+	generateCmd.AddCommand(generateKeypair)
+}
+
+func runGenerateKeypair(cmd *cobra.Command, args []string) {
+
+	conf := generateCtx.Value(k("server.config")).(*server.GenerateConfig)
+
+	crypto.NewEd25519KeyPairFile(conf.Path)
+
+}

--- a/cmd/generate_signerkeys.go
+++ b/cmd/generate_signerkeys.go
@@ -17,26 +17,27 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/bbva/qed/crypto"
 	"github.com/spf13/cobra"
-
-	"github.com/bbva/qed/server"
 )
 
-var generateKeypair *cobra.Command = &cobra.Command{
-	Use:   "keypair",
-	Short: "Generate keypair",
-	Run:   runGenerateKeypair,
+var generateSignerKeys *cobra.Command = &cobra.Command{
+	Use:   "signerkeys",
+	Short: "Generate Signer Keys",
+	Run:   runGenerateSignerKeys,
 }
 
 func init() {
-	generateCmd.AddCommand(generateKeypair)
+	generateCmd.AddCommand(generateSignerKeys)
 }
 
-func runGenerateKeypair(cmd *cobra.Command, args []string) {
+func runGenerateSignerKeys(cmd *cobra.Command, args []string) {
 
-	conf := generateCtx.Value(k("server.config")).(*server.GenerateConfig)
+	conf := generateCtx.Value(k("generate.config")).(*GenerateConfig)
 
-	crypto.NewEd25519KeyPairFile(conf.Path)
+	pubKey, priKey, _ := crypto.NewEd25519SignerKeysFile(conf.Path)
+	fmt.Printf("New signer keys generated at:\n%v\n%v\n", pubKey, priKey)
 
 }

--- a/config.example.yml
+++ b/config.example.yml
@@ -30,7 +30,7 @@ profiling: false  # Allow a pprof url (localhost:6060) for profiling purposes.
 server:
   node_id: "hostname"  # Unique name for node. If not set, fallback to hostname.
   metrics: false # Allow metrics 
-  key: "/var/tmp/qed/id_ed25519"  # Path to the ed25519 key file.
+  key: "/var/tmp/qed/qed_ed25519"  # Path to the ed25519 key file.
   tls:
     certificate: "/var/tmp/qed/server.crt" # Server certificate file
     certificate_key: "/var/tmp/qed/server.key" # Server certificate key file

--- a/crypto/keys.go
+++ b/crypto/keys.go
@@ -26,11 +26,11 @@ import (
 func NewEd25519KeyPairFile(path string) {
 	// Generate a new private/public keypair for QED server
 	pubKey, privKey, _ := ed25519.GenerateKey(rand.Reader)
-	err := ioutil.WriteFile(fmt.Sprintf("%s/id_ed25519", path), privKey, 0644)
+	err := ioutil.WriteFile(path+"/id_ed25519", privKey, 0644)
 	if err != nil {
 		panic(err)
 	}
-	_ = ioutil.WriteFile(fmt.Sprintf("%s/id_ed25519.pub", path), pubKey, 0644)
+	_ = ioutil.WriteFile(path+"/id_ed25519.pub", pubKey, 0644)
 
 	fmt.Printf("New keypair generated => %v/id_ed25519|.pub\n", path)
 }

--- a/crypto/keys.go
+++ b/crypto/keys.go
@@ -17,20 +17,25 @@ package crypto
 
 import (
 	"crypto/rand"
-	"fmt"
 	"io/ioutil"
 
+	"github.com/bbva/qed/log"
 	"golang.org/x/crypto/ed25519"
 )
 
-func NewEd25519KeyPairFile(path string) {
-	// Generate a new private/public keypair for QED server
-	pubKey, privKey, _ := ed25519.GenerateKey(rand.Reader)
-	err := ioutil.WriteFile(path+"/id_ed25519", privKey, 0644)
-	if err != nil {
-		panic(err)
-	}
-	_ = ioutil.WriteFile(path+"/id_ed25519.pub", pubKey, 0644)
+func NewEd25519SignerKeysFile(path string) (string, string, error) {
+	// Generate a new private/public signer keys for QED server
+	outPriv := path + "/qed_ed25519"
+	outPub := outPriv + ".pub"
 
-	fmt.Printf("New keypair generated => %v/id_ed25519|.pub\n", path)
+	pubKey, privKey, _ := ed25519.GenerateKey(rand.Reader)
+
+	err := ioutil.WriteFile(outPriv, privKey, 0644)
+	if err != nil {
+		log.Fatal(err)
+		return outPub, outPriv, err
+	}
+	_ = ioutil.WriteFile(outPub, pubKey, 0644)
+
+	return outPub, outPriv, nil
 }

--- a/crypto/keys.go
+++ b/crypto/keys.go
@@ -1,0 +1,36 @@
+/*
+   Copyright 2018-2019 Banco Bilbao Vizcaya Argentaria, n.A.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package crypto
+
+import (
+	"crypto/rand"
+	"fmt"
+	"io/ioutil"
+
+	"golang.org/x/crypto/ed25519"
+)
+
+func NewEd25519KeyPairFile(path string) {
+	// Generate a new private/public keypair for QED server
+	pubKey, privKey, _ := ed25519.GenerateKey(rand.Reader)
+	err := ioutil.WriteFile(fmt.Sprintf("%s/id_ed25519", path), privKey, 0644)
+	if err != nil {
+		panic(err)
+	}
+	_ = ioutil.WriteFile(fmt.Sprintf("%s/id_ed25519.pub", path), pubKey, 0644)
+
+	fmt.Printf("New keypair generated => %v/id_ed25519|.pub\n", path)
+}

--- a/deploy/aws/config_build.sh
+++ b/deploy/aws/config_build.sh
@@ -31,7 +31,7 @@ if [ ! -f ${node_path} ]; then (
 
 if [ ! -f ${sign_path} ]; then
     #build shared signing key
-    $QED generate keypair --path ${sign_path}
+    $QED generate signerkeys --path ${sign_path}
 fi
 
 if [ ! -f ${cert_path} ] && [ ! -f ${key_path} ]; then

--- a/deploy/aws/config_build.sh
+++ b/deploy/aws/config_build.sh
@@ -6,10 +6,14 @@ function _readlink() { (
   echo $PWD/$(basename $1)
 ) }
 
+# Deployment options
+CGO_LDFLAGS_ALLOW='.*'
+QED="go run $GOPATH/src/github.com/bbva/qed/main.go"
+
 pub=$(_readlink ./config_files)
 tdir=$(mktemp -d /tmp/qed_build.XXX)
 
-sign_path=${pub}/id_ed25519
+sign_path=${pub}
 cert_path=${pub}/server.crt
 key_path=${pub}/server.key
 node_path=${pub}/node_exporter
@@ -27,9 +31,7 @@ if [ ! -f ${node_path} ]; then (
 
 if [ ! -f ${sign_path} ]; then
     #build shared signing key
-    ssh-keygen -t ed25519 -f id_ed25519 -P ''
-
-    cp id_ed25519 ${sign_path}
+    $QED generate keypair --path ${sign_path}
 fi
 
 if [ ! -f ${cert_path} ] && [ ! -f ${key_path} ]; then

--- a/deploy/aws/config_files/README.md
+++ b/deploy/aws/config_files/README.md
@@ -5,7 +5,7 @@ This folder is a placeholder to deploy in the `qed` servers.
 Here you will need the following files. If aren't present, `config_build.sh`
 will generate development ones for testing.
 
-- `id_ed25519` the private key to sing the snapshots
+- `qed_ed25519` the private key to sing the snapshots
 - `server.crt` the server certificate to use TLS connections
 - `server.key` the server key to use TLS connections
 

--- a/deploy/provision/main.yml
+++ b/deploy/provision/main.yml
@@ -21,6 +21,8 @@
     - GOOS: linux
     - GOARCH: amd64
     - GO111MODULE: 'on'
+    - CGO_LDFLAGS_ALLOW: '.*'
+    - QED: 'go run ../../main.go'
   tasks:
     - include: tasks/common/build.yml
     - include: tasks/common/config.yml

--- a/deploy/provision/tasks/common/config.yml
+++ b/deploy/provision/tasks/common/config.yml
@@ -18,7 +18,7 @@
       state: directory
 
 - name: Create private key
-  shell: ssh-keygen -t ed25519 -f config_files/id_ed25519 -P ''
+  shell: GOOS="" GOARCH="" $QED generate keypair --path config_files
   args:
     creates: config_files/id_ed25519
 

--- a/deploy/provision/tasks/common/config.yml
+++ b/deploy/provision/tasks/common/config.yml
@@ -18,9 +18,9 @@
       state: directory
 
 - name: Create private key
-  shell: GOOS="" GOARCH="" $QED generate keypair --path config_files
+  shell: GOOS="" GOARCH="" $QED generate signerkeys --path config_files
   args:
-    creates: config_files/id_ed25519
+    creates: config_files/qed_ed25519
 
 - name: Create SSL certs
   shell: >

--- a/deploy/provision/tasks/common/main.yml
+++ b/deploy/provision/tasks/common/main.yml
@@ -96,7 +96,7 @@
   with_items:
     # - server.crt
     # - server.key
-    - id_ed25519
+    - qed_ed25519
 
 - name: Copy CA cert to remote
   copy:

--- a/deploy/provision/templates/qed-start.sh.j2
+++ b/deploy/provision/templates/qed-start.sh.j2
@@ -26,7 +26,7 @@ $QED_HOME/qed server start \
 --metrics-addr "{{ ansible_eth0.ipv4.address }}:8600" \
 --mgmt-addr "{{ ansible_eth0.ipv4.address }}:8700" \
 --node-id server-{{ansible_hostname}} \
---private-key-path /var/qed/id_ed25519 \
+--private-key-path /var/qed/qed_ed25519 \
 --raft-addr "{{ ansible_eth0.ipv4.address }}:8500" \
 {% if groups.role_qed.index(inventory_hostname) != 0  %}
 {% for host in groups['name_qed-0'] %}

--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -23,7 +23,7 @@ go run main.go start \
     -k my-key \
     -p $(mktemp -d /var/tmp/demo.XXX) \
     --raftpath $(mktemp -d /var/tmp/demo.XXX) \
-    -y ~/.ssh/id_ed25519-qed \
+    -y ~/.ssh/qed_ed25519 \
     --http-addr :8800 \
     --raft-addr :8500 \
     --mgmt-addr :8700 \
@@ -38,7 +38,7 @@ for i in $(seq 1 $FOLLOWERS); do
         -k my-key \
         -p $(mktemp -d /var/tmp/demo.XXX) \
         --raftpath $(mktemp -d /var/tmp/demo.XXX) \
-        -y ~/.ssh/id_ed25519-qed \
+        -y ~/.ssh/qed_ed25519 \
         --http-addr :808$i \
         --join-addr :8700 \
         --raft-addr :900$i \

--- a/server/config.go
+++ b/server/config.go
@@ -81,11 +81,6 @@ type Config struct {
 	SSLCertificateKey string
 }
 
-type GenerateConfig struct {
-	// Path to the private key file used to sign snapshots.
-	Path string
-}
-
 func DefaultConfig() *Config {
 	hostname, _ := os.Hostname()
 	currentDir := getCurrentDir()
@@ -109,12 +104,6 @@ func DefaultConfig() *Config {
 		SSLCertificate:    "",
 		SSLCertificateKey: "",
 		PrivateKeyPath:    "",
-	}
-}
-
-func GenerateDefaultConfig() *GenerateConfig {
-	return &GenerateConfig{
-		Path: "/var/tmp",
 	}
 }
 

--- a/server/config.go
+++ b/server/config.go
@@ -81,6 +81,11 @@ type Config struct {
 	SSLCertificateKey string
 }
 
+type GenerateConfig struct {
+	// Path to the private key file used to sign snapshots.
+	Path string
+}
+
 func DefaultConfig() *Config {
 	hostname, _ := os.Hostname()
 	currentDir := getCurrentDir()
@@ -103,6 +108,13 @@ func DefaultConfig() *Config {
 		ProfilingAddr:     "127.0.0.1:6060",
 		SSLCertificate:    "",
 		SSLCertificateKey: "",
+		PrivateKeyPath:    "",
+	}
+}
+
+func GenerateDefaultConfig() *GenerateConfig {
+	return &GenerateConfig{
+		Path: "/var/tmp",
 	}
 }
 

--- a/sign/sign.go
+++ b/sign/sign.go
@@ -19,10 +19,10 @@ package sign
 import (
 	"crypto/rand"
 	"errors"
+	"fmt"
 	"io/ioutil"
 
 	"golang.org/x/crypto/ed25519"
-	"golang.org/x/crypto/ssh"
 )
 
 type Signer interface {
@@ -56,15 +56,14 @@ func NewEd25519SignerFromFile(privateKeyPath string) (Signer, error) {
 		return nil, err
 	}
 
-	pk, err := ssh.ParseRawPrivateKey(privateKeyBytes)
-	privateKey := *pk.(*ed25519.PrivateKey)
+	publicKeyBytes, err := ioutil.ReadFile(fmt.Sprintf("%v.pub", privateKeyPath))
 	if err != nil {
 		return nil, err
 	}
 
 	signer := &Ed25519Signer{
-		privateKey,
-		privateKey.Public().(ed25519.PublicKey),
+		privateKeyBytes,
+		publicKeyBytes,
 	}
 
 	message := []byte("test message")

--- a/tests/build_certs
+++ b/tests/build_certs
@@ -6,10 +6,14 @@ function _readlink() { (
   echo $PWD/$(basename $1)
 ) }
 
+# Deployment options
+CGO_LDFLAGS_ALLOW='.*'
+QED="go run $GOPATH/src/github.com/bbva/qed/main.go"
+
 pub=$(_readlink /var/tmp/certs)
 tdir=$(mktemp -d /tmp/qed_build.XXX)
 mkdir -p $pub
-sign_path=${pub}/id_ed25519
+sign_path=${pub}
 cert_path=${pub}/server.crt
 key_path=${pub}/server.key
 
@@ -18,9 +22,7 @@ cd ${tdir}
 
 if [ ! -f ${sign_path} ]; then
     #build shared signing key
-    ssh-keygen -t ed25519 -f id_ed25519 -P ''
-
-    cp id_ed25519 ${sign_path}
+    $QED generate keypair --path ${sign_path}
 fi
 
 if [ ! -f ${cert_path} ] && [ ! -f ${key_path} ]; then

--- a/tests/build_certs
+++ b/tests/build_certs
@@ -22,7 +22,7 @@ cd ${tdir}
 
 if [ ! -f ${sign_path} ]; then
     #build shared signing key
-    $QED generate keypair --path ${sign_path}
+    $QED generate signerkeys --path ${sign_path}
 fi
 
 if [ ! -f ${cert_path} ] && [ ! -f ${key_path} ]; then

--- a/tests/cloud/aws/templates/start_master
+++ b/tests/cloud/aws/templates/start_master
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-echo Create id_ed25519 key
-/tmp/to_upload/qed generate keypair --path /var/tmp
+echo Create qed_ed25519 key
+/tmp/to_upload/qed generate signerkeys --path /var/tmp
 
 echo Starting server...
-nohup /tmp/to_upload/qed start -k pepe -p $(mktemp -d /var/tmp/demo.XXX) --raftpath $(mktemp -d /var/tmp/demo.XXX) -y /var/tmp/id_ed25519 -l error --http-addr ${master_address}:8800 --raft-addr ${master_address}:8500 --mgmt-addr ${master_address}:8700 &
+nohup /tmp/to_upload/qed start -k pepe -p $(mktemp -d /var/tmp/demo.XXX) --raftpath $(mktemp -d /var/tmp/demo.XXX) -y /var/tmp/qed_ed25519 -l error --http-addr ${master_address}:8800 --raft-addr ${master_address}:8500 --mgmt-addr ${master_address}:8700 &
 echo done.
 
 sleep 10

--- a/tests/cloud/aws/templates/start_master
+++ b/tests/cloud/aws/templates/start_master
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 echo Create id_ed25519 key
-yes | ssh-keygen -t ed25519 -N '' -f /var/tmp/id_ed25519
+/tmp/to_upload/qed generate keypair --path /var/tmp/id_ed25519
 
 echo Starting server...
 nohup /tmp/to_upload/qed start -k pepe -p $(mktemp -d /var/tmp/demo.XXX) --raftpath $(mktemp -d /var/tmp/demo.XXX) -y /var/tmp/id_ed25519 -l error --http-addr ${master_address}:8800 --raft-addr ${master_address}:8500 --mgmt-addr ${master_address}:8700 &

--- a/tests/cloud/aws/templates/start_master
+++ b/tests/cloud/aws/templates/start_master
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 echo Create id_ed25519 key
-/tmp/to_upload/qed generate keypair --path /var/tmp/id_ed25519
+/tmp/to_upload/qed generate keypair --path /var/tmp
 
 echo Starting server...
 nohup /tmp/to_upload/qed start -k pepe -p $(mktemp -d /var/tmp/demo.XXX) --raftpath $(mktemp -d /var/tmp/demo.XXX) -y /var/tmp/id_ed25519 -l error --http-addr ${master_address}:8800 --raft-addr ${master_address}:8500 --mgmt-addr ${master_address}:8700 &

--- a/tests/cloud/aws/templates/start_slave01
+++ b/tests/cloud/aws/templates/start_slave01
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-echo Create id_ed25519 key
-yes | ssh-keygen -t ed25519 -N '' -f /var/tmp/id_ed25519
+# build shared signing key
+/tmp/to_upload/qed generate keypair --path /var/tmp/id_ed25519
 
 sleep 10
 

--- a/tests/cloud/aws/templates/start_slave01
+++ b/tests/cloud/aws/templates/start_slave01
@@ -15,12 +15,12 @@
 # limitations under the License.
 
 # build shared signing key
-/tmp/to_upload/qed generate keypair --path /var/tmp/id_ed25519
+/tmp/to_upload/qed generate signerkeys --path /var/tmp/qed_ed25519
 
 sleep 10
 
 echo Starting slave01...
-nohup /tmp/to_upload/qed start -k pepe -p $(mktemp -d /var/tmp/demo.XXX) --raftpath $(mktemp -d /var/tmp/demo.XXX) -y /var/tmp/id_ed25519 -l error --http-addr ${slave01_address}:8081 --join-addr ${master_address}:8700 --raft-addr ${slave01_address}:9001 --mgmt-addr ${slave01_address}:8091 --node-id slave1 &
+nohup /tmp/to_upload/qed start -k pepe -p $(mktemp -d /var/tmp/demo.XXX) --raftpath $(mktemp -d /var/tmp/demo.XXX) -y /var/tmp/qed_ed25519 -l error --http-addr ${slave01_address}:8081 --join-addr ${master_address}:8700 --raft-addr ${slave01_address}:9001 --mgmt-addr ${slave01_address}:8091 --node-id slave1 &
 echo done.
 
 sleep 10

--- a/tests/cloud/aws/templates/start_slave02
+++ b/tests/cloud/aws/templates/start_slave02
@@ -19,7 +19,7 @@ CGO_LDFLAGS_ALLOW='.*'
 QED="go run $GOPATH/src/github.com/bbva/qed/main.go"
 
 # build shared signing key
-$QED generate keypair --path /var/tmp/id_ed25519
+$QED generate keypair --path /var/tmp
 
 sleep 10
 

--- a/tests/cloud/aws/templates/start_slave02
+++ b/tests/cloud/aws/templates/start_slave02
@@ -19,12 +19,12 @@ CGO_LDFLAGS_ALLOW='.*'
 QED="go run $GOPATH/src/github.com/bbva/qed/main.go"
 
 # build shared signing key
-$QED generate keypair --path /var/tmp
+$QED generate signerkeys --path /var/tmp
 
 sleep 10
 
 echo Starting slave02...
-nohup /tmp/to_upload/qed start -k pepe -p $(mktemp -d /var/tmp/demo.XXX) --raftpath $(mktemp -d /var/tmp/demo.XXX) -y /var/tmp/id_ed25519 -l error --http-addr ${slave02_address}:8081 --join-addr ${master_address}:8700 --raft-addr ${slave02_address}:9001 --mgmt-addr ${slave02_address}:8091 --node-id slave2 &
+nohup /tmp/to_upload/qed start -k pepe -p $(mktemp -d /var/tmp/demo.XXX) --raftpath $(mktemp -d /var/tmp/demo.XXX) -y /var/tmp/qed_ed25519 -l error --http-addr ${slave02_address}:8081 --join-addr ${master_address}:8700 --raft-addr ${slave02_address}:9001 --mgmt-addr ${slave02_address}:8091 --node-id slave2 &
 echo done.
 
 sleep 10

--- a/tests/cloud/aws/templates/start_slave02
+++ b/tests/cloud/aws/templates/start_slave02
@@ -14,8 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-echo Create id_ed25519 key
-yes | ssh-keygen -t ed25519 -N '' -f /var/tmp/id_ed25519
+# Deployment options
+CGO_LDFLAGS_ALLOW='.*'
+QED="go run $GOPATH/src/github.com/bbva/qed/main.go"
+
+# build shared signing key
+$QED generate keypair --path /var/tmp/id_ed25519
 
 sleep 10
 

--- a/tests/cloud/aws/templates/stress-throughput-60s
+++ b/tests/cloud/aws/templates/stress-throughput-60s
@@ -19,7 +19,7 @@ CGO_LDFLAGS_ALLOW='.*'
 QED="go run $GOPATH/src/github.com/bbva/qed/main.go"
 
 # build shared signing key
-$QED generate keypair --path /var/tmp/id_ed25519
+$QED generate keypair --path /var/tmp
 
 echo Stress time!
 

--- a/tests/cloud/aws/templates/stress-throughput-60s
+++ b/tests/cloud/aws/templates/stress-throughput-60s
@@ -14,8 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-echo Create id_ed25519 key
-yes | ssh-keygen -t ed25519 -N '' -f /var/tmp/id_ed25519
+# Deployment options
+CGO_LDFLAGS_ALLOW='.*'
+QED="go run $GOPATH/src/github.com/bbva/qed/main.go"
+
+# build shared signing key
+$QED generate keypair --path /var/tmp/id_ed25519
 
 echo Stress time!
 

--- a/tests/cloud/aws/templates/stress-throughput-60s
+++ b/tests/cloud/aws/templates/stress-throughput-60s
@@ -19,7 +19,7 @@ CGO_LDFLAGS_ALLOW='.*'
 QED="go run $GOPATH/src/github.com/bbva/qed/main.go"
 
 # build shared signing key
-$QED generate keypair --path /var/tmp
+$QED generate signerkeys --path /var/tmp
 
 echo Stress time!
 
@@ -30,5 +30,5 @@ echo done.
 echo Cleanup...
 /sbin/fuser -k -n tcp 8800
 rm -rf /var/tmp/demo.*
-rm -f /var/tmp/id_ed25519{,.pub}
+rm -f /var/tmp/qed_ed25519{,.pub}
 echo done.

--- a/tests/demo/start-follower1
+++ b/tests/demo/start-follower1
@@ -18,7 +18,7 @@ echo 'Starting follower #1...'
 go run ../../main.go start \
     -k test_key \
     -p $(mktemp -d /var/tmp/demo.XXX) \
-    --keypath /var/tmp/id_ed25519 \
+    --keypath /var/tmp/qed_ed25519 \
     -l debug \
     --http-addr :8801 \
     --mgmt-addr :8701 \

--- a/tests/demo/start-follower2
+++ b/tests/demo/start-follower2
@@ -18,7 +18,7 @@ echo 'Starting follower #2...'
 go run ../../main.go start \
     -k test_key \
     -p $(mktemp -d /var/tmp/demo.XXX) \
-    --raftpath /var/tmp/id_ed25519 \
+    --raftpath /var/tmp/qed_ed25519 \
     -l debug \
     --http-addr :8802 \
     --mgmt-addr :8702 \

--- a/tests/demo/start-leader
+++ b/tests/demo/start-leader
@@ -19,7 +19,7 @@ CGO_LDFLAGS_ALLOW='.*'
 QED="go run $GOPATH/src/github.com/bbva/qed/main.go"
 
 # build shared signing key
-$QED generate keypair --path /var/tmp/id_ed25519
+$QED generate keypair --path /var/tmp
 
 tdir=$(mktemp -d /var/tmp/demo.XXX)
 

--- a/tests/demo/start-leader
+++ b/tests/demo/start-leader
@@ -14,13 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-echo Create id_ed25519 key
-ssh-keygen -t ed25519 -N '' -f /var/tmp/id_ed25519
+# Deployment options
+CGO_LDFLAGS_ALLOW='.*'
+QED="go run $GOPATH/src/github.com/bbva/qed/main.go"
+
+# build shared signing key
+$QED generate keypair --path /var/tmp/id_ed25519
 
 tdir=$(mktemp -d /var/tmp/demo.XXX)
 
 echo 'Starting leader...'
-go run ../../main.go start \
+go run $QED start \
     -k test_key \
     -p ${tdir} \
     --keypath /var/tmp/id_ed25519 \

--- a/tests/demo/start-leader
+++ b/tests/demo/start-leader
@@ -19,7 +19,7 @@ CGO_LDFLAGS_ALLOW='.*'
 QED="go run $GOPATH/src/github.com/bbva/qed/main.go"
 
 # build shared signing key
-$QED generate keypair --path /var/tmp
+$QED generate signerkeys --path /var/tmp
 
 tdir=$(mktemp -d /var/tmp/demo.XXX)
 
@@ -27,7 +27,7 @@ echo 'Starting leader...'
 go run $QED start \
     -k test_key \
     -p ${tdir} \
-    --keypath /var/tmp/id_ed25519 \
+    --keypath /var/tmp/qed_ed25519 \
     -l debug \
     --http-addr :8800 \
     --raft-addr :8500 \
@@ -42,5 +42,5 @@ else
 fi
 
 rm -rf /var/tmp/demo.*
-rm -f /var/tmp/id_ed25519{,.pub}
+rm -f /var/tmp/qed_ed25519{,.pub}
 echo done.

--- a/tests/e2e/setup.go
+++ b/tests/e2e/setup.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/bbva/qed/client"
+	"github.com/bbva/qed/crypto"
 	"github.com/bbva/qed/hashing"
 	"github.com/bbva/qed/server"
 	"github.com/bbva/qed/testutils/keys"
@@ -139,7 +140,8 @@ func newServerSetup(id int, tls bool) (func() error, func() error) {
 		if err != nil {
 			return err
 		}
-		signKeyPath, err := keys.GenerateSignKey(path)
+
+		_, signKeyPath, err := crypto.NewEd25519SignerKeysFile(path)
 		if err != nil {
 			return err
 		}

--- a/tests/start_server
+++ b/tests/start_server
@@ -17,7 +17,7 @@
 CGO_LDFLAGS_ALLOW='.*'
 QED="go run $GOPATH/src/github.com/bbva/qed/main.go"
 
-$QED generate keypair
+$QED generate signerkeys
 
 # Server options
 LEADER_CONFIG=()
@@ -29,7 +29,7 @@ LEADER_CONFIG+=('--http-addr 127.0.0.1:880${i}')
 LEADER_CONFIG+=('--metrics-addr 127.0.0.1:860${i}')
 LEADER_CONFIG+=('--mgmt-addr 127.0.0.1:870${i}')
 LEADER_CONFIG+=('--node-id server${i}')
-LEADER_CONFIG+=('--private-key-path /var/tmp/id_ed25519')
+LEADER_CONFIG+=('--private-key-path /var/tmp/qed_ed25519')
 LEADER_CONFIG+=('--raft-addr 127.0.0.1:850${i}')
 LEADER_CONFIG+=('--raft-path /var/tmp/qed${i}/wal')
 LEADER_CONFIG+=('--enable-profiling')

--- a/tests/start_server
+++ b/tests/start_server
@@ -14,15 +14,10 @@
 #  limitations under the License.
 
 # Deployment options
-keyFile="/var/tmp/id_ed25519"
-
-if [ ! -f "$keyFile" ]; then
-	echo Create id_ed25519 key
-	echo -e 'y\n' | ssh-keygen -t ed25519 -N '' -f /var/tmp/id_ed25519
-fi
-
 CGO_LDFLAGS_ALLOW='.*'
 QED="go run $GOPATH/src/github.com/bbva/qed/main.go"
+
+$QED generate keypair
 
 # Server options
 LEADER_CONFIG=()

--- a/testutils/keys/keys.go
+++ b/testutils/keys/keys.go
@@ -22,34 +22,16 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"os"
 	"time"
+
+	"github.com/bbva/qed/crypto"
 )
 
 func GenerateSignKey(path string) (string, error) {
-	/* public, private, err := ed25519.GenerateKey(nil)
-	if err != nil {
-		return "", err
-	} */
-
-	err := ioutil.WriteFile(path+"/id_ed25519", []byte(`-----BEGIN OPENSSH PRIVATE KEY-----
-b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
-QyNTUxOQAAACCXiy9taNh+avmEAyzfnlCXxYHzgS3wGPCi52AY8qQyTwAAAKA6Sq8iOkqv
-IgAAAAtzc2gtZWQyNTUxOQAAACCXiy9taNh+avmEAyzfnlCXxYHzgS3wGPCi52AY8qQyTw
-AAAEAzpsL9rtrmKhL3cEHFcKPEvkd8y/QJXeFTtyhgaYfUDpeLL21o2H5q+YQDLN+eUJfF
-gfOBLfAY8KLnYBjypDJPAAAAHWdkaWF6bG9AbWFjc2xhY2suc2xhY2t3YXJlLmVz
------END OPENSSH PRIVATE KEY-----
-`), 0644)
-	if err != nil {
-		return "", err
-	}
-	err = ioutil.WriteFile(path+"/id_ed25519.pub", []byte("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJeLL21o2H5q+YQDLN+eUJfFgfOBLfAY8KLnYBjypDJP gdiazlo@macslack.slackware.es"), 0644)
-	if err != nil {
-		return "", err
-	}
+	crypto.NewEd25519KeyPairFile(path)
 
 	return path + "/id_ed25519", nil
 }

--- a/testutils/keys/keys.go
+++ b/testutils/keys/keys.go
@@ -26,15 +26,7 @@ import (
 	"net"
 	"os"
 	"time"
-
-	"github.com/bbva/qed/crypto"
 )
-
-func GenerateSignKey(path string) (string, error) {
-	crypto.NewEd25519KeyPairFile(path)
-
-	return path + "/id_ed25519", nil
-}
 
 func GenerateTlsCert(path string) (string, error) {
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)


### PR DESCRIPTION
New command **generate** with sub-command **keipair** was created.
This will generate new ed25519 keypair in /var/tmp by default. You also can specify a custom output directory with **--path** flag.
 
Closes #125 