### PR TITLE
Move event hashing out of balloon internals

### DIFF
--- a/balloon/balloon.go
+++ b/balloon/balloon.go
@@ -43,13 +43,6 @@ type Balloon struct {
 	hasher      hashing.Hasher
 }
 
-func min(x, y uint16) uint16 {
-	if x < y {
-		return x
-	}
-	return y
-}
-
 func NewBalloon(store storage.Store, hasherF func() hashing.Hasher) (*Balloon, error) {
 
 	// create trees
@@ -66,7 +59,7 @@ func NewBalloon(store storage.Store, hasherF func() hashing.Hasher) (*Balloon, e
 	}
 
 	// update version
-	balloon.RefreshVersion()
+	_ = balloon.RefreshVersion()
 
 	return balloon, nil
 }

--- a/balloon/balloon.go
+++ b/balloon/balloon.go
@@ -59,7 +59,10 @@ func NewBalloon(store storage.Store, hasherF func() hashing.Hasher) (*Balloon, e
 	}
 
 	// update version
-	_ = balloon.RefreshVersion()
+	err := balloon.RefreshVersion()
+	if err != nil {
+		return nil, err
+	}
 
 	return balloon, nil
 }

--- a/balloon/balloon.go
+++ b/balloon/balloon.go
@@ -176,14 +176,11 @@ func (b *Balloon) RefreshVersion() error {
 	return nil
 }
 
-func (b *Balloon) Add(event []byte) (*Snapshot, []*storage.Mutation, error) {
+func (b *Balloon) Add(eventDigest hashing.Digest) (*Snapshot, []*storage.Mutation, error) {
 
 	// Get version
 	version := b.version
 	b.version++
-
-	// Hash event
-	eventDigest := b.hasher.Do(event)
 
 	// Update trees
 	var historyDigest hashing.Digest
@@ -221,17 +218,14 @@ func (b *Balloon) Add(event []byte) (*Snapshot, []*storage.Mutation, error) {
 	return snapshot, mutations, nil
 }
 
-func (b *Balloon) AddBulk(bulk [][]byte) ([]*Snapshot, []*storage.Mutation, error) {
+func (b *Balloon) AddBulk(eventBulkDigest []hashing.Digest) ([]*Snapshot, []*storage.Mutation, error) {
 
 	// Get version
 	version := b.version
-	b.version += uint64(len(bulk))
+	b.version += uint64(len(eventBulkDigest))
 
-	var eventBulkDigest []hashing.Digest
 	var eventVersions []uint64
-	for i, event := range bulk {
-		// Hash event
-		eventBulkDigest = append(eventBulkDigest, b.hasher.Do(event))
+	for i, _ := range eventBulkDigest {
 		eventVersions = append(eventVersions, version+uint64(i))
 	}
 

--- a/balloon/balloon_test.go
+++ b/balloon/balloon_test.go
@@ -349,7 +349,6 @@ func BenchmarkAddRocksDB(b *testing.B) {
 		require.NoError(b, store.Mutate(mutations))
 		AddTotal.Inc()
 	}
-
 }
 
 func BenchmarkAddBulkRocksDB(b *testing.B) {
@@ -376,7 +375,6 @@ func BenchmarkAddBulkRocksDB(b *testing.B) {
 		require.NoError(b, store.Mutate(mutations))
 		AddTotal.Inc()
 	}
-
 }
 
 func BenchmarkQueryRocksDB(b *testing.B) {
@@ -404,7 +402,6 @@ func BenchmarkQueryRocksDB(b *testing.B) {
 		_, err := balloon.QueryMembershipConsistency(e, uint64(i))
 		require.NoError(b, err)
 	}
-
 }
 
 func BenchmarkQueryRocksDBParallel(b *testing.B) {
@@ -438,5 +435,4 @@ func BenchmarkQueryRocksDBParallel(b *testing.B) {
 			require.NoError(b, err)
 		}
 	})
-
 }

--- a/balloon/history/tree.go
+++ b/balloon/history/tree.go
@@ -56,13 +56,13 @@ func (t *HistoryTree) Add(eventDigest hashing.Digest, version uint64) (hashing.D
 	return rh, visitor.Result(), nil
 }
 
-func (t *HistoryTree) AddBulk(eventDigests []hashing.Digest, versions []uint64) ([]hashing.Digest, []*storage.Mutation, error) {
+func (t *HistoryTree) AddBulk(eventDigests []hashing.Digest, initialVersion uint64) ([]hashing.Digest, []*storage.Mutation, error) {
 
 	visitor := newInsertVisitor(t.hasher, t.writeCache, storage.HistoryTable)
 
 	rootHashes := make([]hashing.Digest, 0)
 	for i, e := range eventDigests {
-		rootHashes = append(rootHashes, pruneToInsert(versions[i], e).Accept(visitor))
+		rootHashes = append(rootHashes, pruneToInsert(initialVersion+uint64(i), e).Accept(visitor))
 	}
 
 	return rootHashes, visitor.Result(), nil

--- a/balloon/hyper/operation.go
+++ b/balloon/hyper/operation.go
@@ -47,7 +47,6 @@ const (
 	collectValueCode
 	collectHashCode
 	getFromPathCode
-	useHashCode
 	noOpCode
 )
 
@@ -189,16 +188,6 @@ func getFromPath(pos position) *operation {
 				log.Fatalf("Oops, something went wrong. Invalid position in audit path")
 			}
 			return hash
-		},
-	}
-}
-
-func useHash(pos position, digest []byte) *operation {
-	return &operation{
-		Code: useHashCode,
-		Pos:  pos,
-		Interpret: func(ops *operationsStack, c *pruningContext) hashing.Digest {
-			return digest
 		},
 	}
 }

--- a/balloon/hyper/tree.go
+++ b/balloon/hyper/tree.go
@@ -95,15 +95,15 @@ func (t *HyperTree) Add(eventDigest hashing.Digest, version uint64) (hashing.Dig
 	return rh, ctx.Mutations, nil
 }
 
-func (t *HyperTree) AddBulk(eventDigests []hashing.Digest, versions []uint64) (hashing.Digest, []*storage.Mutation, error) {
+func (t *HyperTree) AddBulk(eventDigests []hashing.Digest, initialVersion uint64) (hashing.Digest, []*storage.Mutation, error) {
 	t.Lock()
 	defer t.Unlock()
 
 	versionsAsBytes := make([][]byte, 0)
 	digestsAsBytes := make([][]byte, 0)
-	for i, version := range versions {
-		versionsAsBytes = append(versionsAsBytes, util.Uint64AsBytes(version))
-		digestsAsBytes = append(digestsAsBytes, []byte(eventDigests[i]))
+	for i, eventDigest := range eventDigests {
+		versionsAsBytes = append(versionsAsBytes, util.Uint64AsBytes(initialVersion+uint64(i)))
+		digestsAsBytes = append(digestsAsBytes, []byte(eventDigest))
 	}
 
 	// build a stack of operations and then interpret it to generate the root hash

--- a/raftwal/commands/command.go
+++ b/raftwal/commands/command.go
@@ -35,11 +35,11 @@ const (
 )
 
 type AddEventCommand struct {
-	Hash hashing.Digest
+	EventDigest hashing.Digest
 }
 
 type AddEventsBulkCommand struct {
-	Hashes []hashing.Digest
+	EventDigests []hashing.Digest
 }
 
 type MetadataSetCommand struct {

--- a/raftwal/commands/command.go
+++ b/raftwal/commands/command.go
@@ -19,6 +19,7 @@ package commands
 import (
 	"bytes"
 
+	"github.com/bbva/qed/hashing"
 	"github.com/hashicorp/go-msgpack/codec"
 )
 
@@ -34,11 +35,11 @@ const (
 )
 
 type AddEventCommand struct {
-	Event []byte
+	Hash hashing.Digest
 }
 
 type AddEventsBulkCommand struct {
-	Events [][]byte
+	Hashes []hashing.Digest
 }
 
 type MetadataSetCommand struct {

--- a/raftwal/fsm.go
+++ b/raftwal/fsm.go
@@ -150,7 +150,7 @@ func (fsm *BalloonFSM) Apply(l *raft.Log) interface{} {
 		}
 		newState := &fsmState{l.Index, l.Term, fsm.balloon.Version()}
 		if fsm.state.shouldApply(newState) {
-			return fsm.applyAdd(cmd.Event, newState)
+			return fsm.applyAdd(cmd.Hash, newState)
 		}
 		return &fsmAddResponse{error: fmt.Errorf("state already applied!: %+v -> %+v", fsm.state, newState)}
 
@@ -160,9 +160,9 @@ func (fsm *BalloonFSM) Apply(l *raft.Log) interface{} {
 			return &fsmAddBulkResponse{error: err}
 		}
 		// INFO: after applying a bulk there will be a jump in term version due to balloon version mapping.
-		newState := &fsmState{l.Index, l.Term, fsm.balloon.Version() + uint64(len(cmd.Events)-1)}
+		newState := &fsmState{l.Index, l.Term, fsm.balloon.Version() + uint64(len(cmd.Hashes)-1)}
 		if fsm.state.shouldApply(newState) {
-			return fsm.applyAddBulk(cmd.Events, newState)
+			return fsm.applyAddBulk(cmd.Hashes, newState)
 		}
 		return &fsmAddBulkResponse{error: fmt.Errorf("state already applied!: %+v -> %+v", fsm.state, newState)}
 
@@ -263,9 +263,9 @@ func (fsm *BalloonFSM) Close() error {
 	return nil
 }
 
-func (fsm *BalloonFSM) applyAdd(event []byte, state *fsmState) *fsmAddResponse {
+func (fsm *BalloonFSM) applyAdd(eventHash hashing.Digest, state *fsmState) *fsmAddResponse {
 
-	snapshot, mutations, err := fsm.balloon.Add(event)
+	snapshot, mutations, err := fsm.balloon.Add(eventHash)
 	if err != nil {
 		return &fsmAddResponse{error: err}
 	}
@@ -285,9 +285,9 @@ func (fsm *BalloonFSM) applyAdd(event []byte, state *fsmState) *fsmAddResponse {
 	return &fsmAddResponse{snapshot: snapshot}
 }
 
-func (fsm *BalloonFSM) applyAddBulk(events [][]byte, state *fsmState) *fsmAddBulkResponse {
+func (fsm *BalloonFSM) applyAddBulk(hashes []hashing.Digest, state *fsmState) *fsmAddBulkResponse {
 
-	snapshotBulk, mutations, err := fsm.balloon.AddBulk(events)
+	snapshotBulk, mutations, err := fsm.balloon.AddBulk(hashes)
 	if err != nil {
 		return &fsmAddBulkResponse{error: err}
 	}

--- a/raftwal/fsm.go
+++ b/raftwal/fsm.go
@@ -150,7 +150,7 @@ func (fsm *BalloonFSM) Apply(l *raft.Log) interface{} {
 		}
 		newState := &fsmState{l.Index, l.Term, fsm.balloon.Version()}
 		if fsm.state.shouldApply(newState) {
-			return fsm.applyAdd(cmd.Hash, newState)
+			return fsm.applyAdd(cmd.EventDigest, newState)
 		}
 		return &fsmAddResponse{error: fmt.Errorf("state already applied!: %+v -> %+v", fsm.state, newState)}
 
@@ -160,9 +160,9 @@ func (fsm *BalloonFSM) Apply(l *raft.Log) interface{} {
 			return &fsmAddBulkResponse{error: err}
 		}
 		// INFO: after applying a bulk there will be a jump in term version due to balloon version mapping.
-		newState := &fsmState{l.Index, l.Term, fsm.balloon.Version() + uint64(len(cmd.Hashes)-1)}
+		newState := &fsmState{l.Index, l.Term, fsm.balloon.Version() + uint64(len(cmd.EventDigests)-1)}
 		if fsm.state.shouldApply(newState) {
-			return fsm.applyAddBulk(cmd.Hashes, newState)
+			return fsm.applyAddBulk(cmd.EventDigests, newState)
 		}
 		return &fsmAddBulkResponse{error: fmt.Errorf("state already applied!: %+v -> %+v", fsm.state, newState)}
 

--- a/raftwal/fsm_test.go
+++ b/raftwal/fsm_test.go
@@ -202,9 +202,9 @@ func newRaftLog(index, term uint64, command []byte) *raft.Log {
 func newRaftCommand(commandType commands.CommandType, content interface{}) (data []byte) {
 	switch commandType {
 	case commands.AddEventCommandType:
-		data, _ = commands.Encode(commands.AddEventCommandType, &commands.AddEventCommand{Event: content.([]byte)})
+		data, _ = commands.Encode(commands.AddEventCommandType, &commands.AddEventCommand{Hash: content.(hashing.Digest)})
 	case commands.AddEventsBulkCommandType:
-		data, _ = commands.Encode(commands.AddEventsBulkCommandType, &commands.AddEventsBulkCommand{Events: content.([][]byte)})
+		data, _ = commands.Encode(commands.AddEventsBulkCommandType, &commands.AddEventsBulkCommand{Hashes: content.([]hashing.Digest)})
 	default:
 		data = nil
 	}

--- a/raftwal/raft.go
+++ b/raftwal/raft.go
@@ -376,9 +376,9 @@ func (b *RaftBalloon) raftApply(t commands.CommandType, cmd interface{}) (interf
 */
 func (b *RaftBalloon) Add(event []byte) (*balloon.Snapshot, error) {
 	// Hash events
-	eventHash := b.hasherF().Do(event)
+	eventDigest := b.hasherF().Do(event)
 	// Create and apply command.
-	cmd := &commands.AddEventCommand{Hash: eventHash}
+	cmd := &commands.AddEventCommand{EventDigest: eventDigest}
 	resp, err := b.raftApply(commands.AddEventCommandType, cmd)
 	if err != nil {
 		return nil, err
@@ -401,7 +401,7 @@ func (b *RaftBalloon) AddBulk(bulk [][]byte) ([]*balloon.Snapshot, error) {
 		eventHashBulk = append(eventHashBulk, b.hasherF().Do(event))
 	}
 	// Create and apply command.
-	cmd := &commands.AddEventsBulkCommand{Hashes: eventHashBulk}
+	cmd := &commands.AddEventsBulkCommand{EventDigests: eventHashBulk}
 	resp, err := b.raftApply(commands.AddEventsBulkCommandType, cmd)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Move hashing from balloon internals (balloon.go) to Raft (raft.go), just before inserting the command to the WriteAheadLog.

Others:
- AddEventCommand and AddEventBulkCommand modified.
