### PR TITLE
Add the ability to generate Tls certificate with QED command tool

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -25,13 +25,14 @@ import (
 )
 
 type GenerateConfig struct {
-	// Path to the private key file used to sign snapshots.
-	Path string
+	Path     string // Path to the private key file used to sign snapshots.
+	Hostname string // Hostname of IPAddr for which the certificates will be generated.
 }
 
 func GenerateDefaultConfig() *GenerateConfig {
 	return &GenerateConfig{
-		Path: "/var/tmp",
+		Path:     "/var/tmp",
+		Hostname: "127.0.0.1",
 	}
 }
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -25,8 +25,11 @@ import (
 )
 
 type GenerateConfig struct {
-	Path string // Path to the private key file used to sign snapshots.
-	Host string // DNSName or IPAddr for which the certificates will be generated.
+	// Path to the private key file used to sign snapshots.
+	Path string `desc:"Set custom output directory"`
+
+	// DNSName or IPAddr for which the certificates will be generated.
+	Host string `desc:"Set custom DNS name or IP address for new certificates"`
 }
 
 func GenerateDefaultConfig() *GenerateConfig {

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -25,14 +25,14 @@ import (
 )
 
 type GenerateConfig struct {
-	Path     string // Path to the private key file used to sign snapshots.
-	Hostname string // Hostname of IPAddr for which the certificates will be generated.
+	Path string // Path to the private key file used to sign snapshots.
+	Host string // DNSName or IPAddr for which the certificates will be generated.
 }
 
 func GenerateDefaultConfig() *GenerateConfig {
 	return &GenerateConfig{
-		Path:     "/var/tmp",
-		Hostname: "127.0.0.1",
+		Path: "/var/tmp",
+		Host: "127.0.0.1",
 	}
 }
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -35,7 +35,7 @@ type GenerateConfig struct {
 func GenerateDefaultConfig() *GenerateConfig {
 	return &GenerateConfig{
 		Path: "/var/tmp",
-		Host: "127.0.0.1",
+		Host: "localhost",
 	}
 }
 

--- a/cmd/generate_certs.go
+++ b/cmd/generate_certs.go
@@ -26,21 +26,27 @@ import (
 var generateSelfSignedCert *cobra.Command = &cobra.Command{
 	Use:   "self-signed-cert",
 	Short: "Generate Self Signed Certificates",
-	Run:   runGenerateTlsCerts,
+	RunE:  runSelfSignedCert,
 }
 
 func init() {
 	generateCmd.AddCommand(generateSelfSignedCert)
 }
 
-func runGenerateTlsCerts(cmd *cobra.Command, args []string) {
-
+func runSelfSignedCert(cmd *cobra.Command, args []string) error {
+	var err error
 	conf := generateCtx.Value(k("generate.config")).(*GenerateConfig)
+
+	err = urlParseNoSchemaOrPortRequired(conf.Host)
+	if err != nil {
+		return err
+	}
 
 	cert, key, err := crypto.NewSelfSignedCert(conf.Path, conf.Host)
 	if err != nil {
 		fmt.Errorf("Error: %v\n", err)
 	}
-	fmt.Printf("New Tls certificates generated at:\n%v\n%v\n", cert, key)
+	fmt.Printf("New Self Signed Certtifiates generated at:\n%v\n%v\n", cert, key)
 
+	return nil
 }

--- a/cmd/generate_certs.go
+++ b/cmd/generate_certs.go
@@ -1,0 +1,46 @@
+/*
+   Copyright 2018-2019 Banco Bilbao Vizcaya Argentaria, S.A.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/bbva/qed/crypto"
+	"github.com/spf13/cobra"
+)
+
+var generateTlsCerts *cobra.Command = &cobra.Command{
+	Use:   "tlscerts",
+	Short: "Generate Tls Certificates",
+	Run:   runGenerateTlsCerts,
+}
+
+func init() {
+	generateCmd.AddCommand(generateTlsCerts)
+}
+
+func runGenerateTlsCerts(cmd *cobra.Command, args []string) {
+
+	conf := generateCtx.Value(k("generate.config")).(*GenerateConfig)
+
+	certs, err := crypto.NewTlsCerts(conf.Path)
+	if err != nil {
+		fmt.Errorf("Error: %v\n", err)
+	}
+	fmt.Printf("New Tls certificates generated at:\n%v\n", certs)
+
+}

--- a/cmd/generate_certs.go
+++ b/cmd/generate_certs.go
@@ -44,7 +44,7 @@ func runSelfSignedCert(cmd *cobra.Command, args []string) error {
 
 	cert, key, err := crypto.NewSelfSignedCert(conf.Path, conf.Host)
 	if err != nil {
-		fmt.Errorf("Error: %v\n", err)
+		return fmt.Errorf("Error: %v", err)
 	}
 	fmt.Printf("New Self Signed Certtifiates generated at:\n%v\n%v\n", cert, key)
 

--- a/cmd/generate_certs.go
+++ b/cmd/generate_certs.go
@@ -23,21 +23,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var generateTlsCerts *cobra.Command = &cobra.Command{
-	Use:   "tlscerts",
-	Short: "Generate Tls Certificates",
+var generateSelfSignedCert *cobra.Command = &cobra.Command{
+	Use:   "self-signed-cert",
+	Short: "Generate Self Signed Certificates",
 	Run:   runGenerateTlsCerts,
 }
 
 func init() {
-	generateCmd.AddCommand(generateTlsCerts)
+	generateCmd.AddCommand(generateSelfSignedCert)
 }
 
 func runGenerateTlsCerts(cmd *cobra.Command, args []string) {
 
 	conf := generateCtx.Value(k("generate.config")).(*GenerateConfig)
 
-	cert, key, err := crypto.NewTlsCerts(conf.Path, conf.Host)
+	cert, key, err := crypto.NewSelfSignedCert(conf.Path, conf.Host)
 	if err != nil {
 		fmt.Errorf("Error: %v\n", err)
 	}

--- a/cmd/generate_certs.go
+++ b/cmd/generate_certs.go
@@ -37,10 +37,10 @@ func runGenerateTlsCerts(cmd *cobra.Command, args []string) {
 
 	conf := generateCtx.Value(k("generate.config")).(*GenerateConfig)
 
-	certs, err := crypto.NewTlsCerts(conf.Path)
+	cert, key, err := crypto.NewTlsCerts(conf.Path, conf.Hostname)
 	if err != nil {
 		fmt.Errorf("Error: %v\n", err)
 	}
-	fmt.Printf("New Tls certificates generated at:\n%v\n", certs)
+	fmt.Printf("New Tls certificates generated at:\n%v\n%v\n", cert, key)
 
 }

--- a/cmd/generate_certs.go
+++ b/cmd/generate_certs.go
@@ -37,7 +37,7 @@ func runGenerateTlsCerts(cmd *cobra.Command, args []string) {
 
 	conf := generateCtx.Value(k("generate.config")).(*GenerateConfig)
 
-	cert, key, err := crypto.NewTlsCerts(conf.Path, conf.Hostname)
+	cert, key, err := crypto.NewTlsCerts(conf.Path, conf.Host)
 	if err != nil {
 		fmt.Errorf("Error: %v\n", err)
 	}

--- a/cmd/generate_certs.go
+++ b/cmd/generate_certs.go
@@ -37,9 +37,9 @@ func runSelfSignedCert(cmd *cobra.Command, args []string) error {
 	var err error
 	conf := generateCtx.Value(k("generate.config")).(*GenerateConfig)
 
-	err = urlParseNoSchemaOrPortRequired(conf.Host)
+	err = isValidFQDN(conf.Host)
 	if err != nil {
-		return err
+		return fmt.Errorf("Invalid FQDN: %v", err)
 	}
 
 	cert, key, err := crypto.NewSelfSignedCert(conf.Path, conf.Host)

--- a/cmd/generate_csr.go
+++ b/cmd/generate_csr.go
@@ -44,7 +44,7 @@ func runCsr(cmd *cobra.Command, args []string) error {
 
 	cert, key, err := crypto.NewCsrRequest(conf.Path, conf.Host)
 	if err != nil {
-		fmt.Errorf("Error: %v\n", err)
+		return fmt.Errorf("Error: %v", err)
 	}
 	fmt.Printf("New Certificate Signing Request and Private Key generated at:\n%v\n%v\n", cert, key)
 

--- a/cmd/generate_csr.go
+++ b/cmd/generate_csr.go
@@ -37,9 +37,9 @@ func runCsr(cmd *cobra.Command, args []string) error {
 	var err error
 	conf := generateCtx.Value(k("generate.config")).(*GenerateConfig)
 
-	err = urlParseNoSchemaOrPortRequired(conf.Host)
+	err = isValidFQDN(conf.Host)
 	if err != nil {
-		return err
+		return fmt.Errorf("Invalid FQDN: %v", err)
 	}
 
 	cert, key, err := crypto.NewCsrRequest(conf.Path, conf.Host)

--- a/cmd/generate_csr.go
+++ b/cmd/generate_csr.go
@@ -1,0 +1,52 @@
+/*
+   Copyright 2018-2019 Banco Bilbao Vizcaya Argentaria, S.A.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/bbva/qed/crypto"
+	"github.com/spf13/cobra"
+)
+
+var generateCsrRequest *cobra.Command = &cobra.Command{
+	Use:   "csr",
+	Short: "Generate Certificate Signing Request",
+	RunE:  runCsr,
+}
+
+func init() {
+	generateCmd.AddCommand(generateCsrRequest)
+}
+
+func runCsr(cmd *cobra.Command, args []string) error {
+	var err error
+	conf := generateCtx.Value(k("generate.config")).(*GenerateConfig)
+
+	err = urlParseNoSchemaOrPortRequired(conf.Host)
+	if err != nil {
+		return err
+	}
+
+	cert, key, err := crypto.NewCsrRequest(conf.Path, conf.Host)
+	if err != nil {
+		fmt.Errorf("Error: %v\n", err)
+	}
+	fmt.Printf("New Certificate Signing Request and Private Key generated at:\n%v\n%v\n", cert, key)
+
+	return nil
+}

--- a/cmd/generate_signerkeys.go
+++ b/cmd/generate_signerkeys.go
@@ -26,18 +26,22 @@ import (
 var generateSignerKeys *cobra.Command = &cobra.Command{
 	Use:   "signerkeys",
 	Short: "Generate Signer Keys",
-	Run:   runGenerateSignerKeys,
+	RunE:  runGenerateSignerKeys,
 }
 
 func init() {
 	generateCmd.AddCommand(generateSignerKeys)
 }
 
-func runGenerateSignerKeys(cmd *cobra.Command, args []string) {
+func runGenerateSignerKeys(cmd *cobra.Command, args []string) error {
 
 	conf := generateCtx.Value(k("generate.config")).(*GenerateConfig)
 
-	pubKey, priKey, _ := crypto.NewEd25519SignerKeysFile(conf.Path)
+	pubKey, priKey, err := crypto.NewEd25519SignerKeysFile(conf.Path)
+	if err != nil {
+		return err
+	}
 	fmt.Printf("New signer keys generated at:\n%v\n%v\n", pubKey, priKey)
 
+	return nil
 }

--- a/cmd/generate_signerkeys.go
+++ b/cmd/generate_signerkeys.go
@@ -34,8 +34,13 @@ func init() {
 }
 
 func runGenerateSignerKeys(cmd *cobra.Command, args []string) error {
-
+	var err error
 	conf := generateCtx.Value(k("generate.config")).(*GenerateConfig)
+
+	err = isValidFQDN(conf.Host)
+	if err != nil {
+		return fmt.Errorf("%v", err)
+	}
 
 	pubKey, priKey, err := crypto.NewEd25519SignerKeysFile(conf.Path)
 	if err != nil {

--- a/cmd/parameters.go
+++ b/cmd/parameters.go
@@ -82,10 +82,6 @@ func isLetDigHyp(s rune) bool {
 	return isLetDig(s) || isHyphen(s)
 }
 
-func maxFQDNLen(s string) bool {
-	return 63 > len(s) || 253 > len(s)
-}
-
 func trailingDotHyp(s string) bool {
 	return strings.Contains(s, "..") || strings.Contains(s, "--")
 }
@@ -135,7 +131,7 @@ func isValidFQDN(fqdn string) error {
 	}
 
 	// Check if FQDN have valid length.
-	if 253 < len(fqdn) {
+	if len(fqdn) > 253 {
 		return fmt.Errorf("%s in %s", errFQDNLen, fqdn)
 	}
 
@@ -143,7 +139,7 @@ func isValidFQDN(fqdn string) error {
 		l := components[c]
 
 		// Check if label have valid length.
-		if 63 < len(l) {
+		if len(l) > 63 {
 			return fmt.Errorf("%s in %s", errFQDNLabelLen, fqdn)
 		}
 

--- a/cmd/parameters.go
+++ b/cmd/parameters.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"unicode"
 )
 
 const (
@@ -28,9 +29,141 @@ const (
 	errMissingURLHost   = "missing URL Host"
 	errMissingURLPort   = "missing URL Port"
 	errUnexpectedScheme = "unexpected URL Scheme"
-	errNoShemaRequired  = "URL Schema is not required"
-	errNoPortRequired   = "Port is not required"
+	errFQDN             = "not a valid FQDN"
+	errFQDNInvalid      = "only letters(a-z|A-Z), digits(0-9) and hyphens('-') for labels"
+	errFQDNTrailing     = "trailing dot or hyphens are not allowed"
+	errFQDNLen          = "max FQDN length is 253"
+	errFQDNLabelLen     = "max FQDN length is 63"
+	errFQDNEmptyDot     = "start or end with dots is not allowed"
+	errFQDNHyp          = "labels cannot start or end with hyphens"
+	errTLDLen           = "TLD length is not valid"
+	errTLDLet           = "TLD allow only letters"
 )
+
+/*
+Hostname FQDN validation
+Hostnames are composed of a series of labels concatenated with dots.
+Each label is 1 to 63 characters long, and may contain: the ASCII letters
+a-z and A-Z, the digits 0-9, and the hyphen ('-'). Additionally: labels
+cannot start or end with hyphens (RFC 952) labels can start with
+numbers (RFC 1123) trailing dot is not allowed max length of ascii
+hostname including dots is 253 characters TLD (last label) is at least 2
+characters and only ASCII letters we want at least 1 level above TLD
+Source: https://stackoverflow.com/questions/11809631/fully-qualified-domain-
+name-validation, answer from JdeBP
+
+<domain> ::= <subdomain> | " "
+<subdomain> ::= <label> | <subdomain> "." <label>
+<label> ::= <letter> [ [ <ldh-str> ] <let-dig> ]
+<ldh-str> ::= <let-dig-hyp> | <let-dig-hyp> <ldh-str>
+<let-dig-hyp> ::= <let-dig> | "-"
+<let-dig> ::= <letter> | <digit>
+<letter> ::= any one of the 52 alphabetic characters A through Z in
+upper case and a through z in lower case
+<digit> ::= any one of the ten digits 0 through 9
+*/
+
+func isHyphen(s rune) bool {
+	return s == '-'
+}
+
+func isLet(s []rune) bool {
+	for l := range s {
+		return unicode.IsLetter(s[l])
+	}
+	return true
+}
+
+func isLetDig(s rune) bool {
+	return unicode.IsLetter(s) || unicode.IsDigit(s)
+}
+
+func isLetDigHyp(s rune) bool {
+	return isLetDig(s) || isHyphen(s)
+}
+
+func maxFQDNLen(s string) bool {
+	return 63 > len(s) || 253 > len(s)
+}
+
+func trailingDotHyp(s string) bool {
+	return strings.Contains(s, "..") || strings.Contains(s, "--")
+}
+
+func isLabel(label []rune) bool {
+
+	for _, s := range label {
+		if !isLetDigHyp(rune(s)) {
+			return false
+		}
+	}
+
+	if !isLetDigHyp(label[0]) {
+		return false
+	}
+
+	return true
+}
+
+func isSubDomain(names []string) bool {
+	for _, s := range names {
+		if len(s) < 1 || !isLabel([]rune(s)) {
+			return false
+		}
+	}
+	return true
+}
+
+func isValidFQDN(fqdn string) error {
+
+	components := strings.Split(fqdn, ".")
+	label := []rune(components[len(components)-1])
+
+	// Check TLD length.
+	if 1 == len(label) {
+		return fmt.Errorf("%s in %s", errTLDLen, fqdn)
+	}
+
+	// Check if TLD valid. Only letters ar allowed.
+	if !isLet(label) {
+		return fmt.Errorf("%s in %s", errTLDLet, fqdn)
+	}
+
+	// Check for invalid trailings.
+	if trailingDotHyp(fqdn) {
+		return fmt.Errorf("%s in %s", errFQDNTrailing, fqdn)
+	}
+
+	// Check if FQDN have valid length.
+	if 253 < len(fqdn) {
+		return fmt.Errorf("%s in %s", errFQDNLen, fqdn)
+	}
+
+	for c := range components {
+		l := components[c]
+
+		// Check if label have valid length.
+		if 63 < len(l) {
+			return fmt.Errorf("%s in %s", errFQDNLabelLen, fqdn)
+		}
+
+		// Check for empty values in components. Eg: acme.net.
+		if l == "" {
+			return fmt.Errorf("%s in %s", errFQDNEmptyDot, fqdn)
+		}
+
+		// Check for hyphens at begining|end.
+		if isHyphen(rune(l[0])) || isHyphen(rune(l[(len(l)-1)])) {
+			return fmt.Errorf("%s in %s", errFQDNHyp, fqdn)
+		}
+	}
+
+	if !isSubDomain(components) {
+		return fmt.Errorf("%s in %s", errFQDNInvalid, fqdn)
+	}
+
+	return nil
+}
 
 // urlParse function checks that given string parameters are valid URLs for
 // REST requests: schema + hostname [ + port ]
@@ -75,31 +208,6 @@ func urlParseNoSchemaRequired(endpoints ...string) error {
 
 		if url.Port() == "" {
 			return fmt.Errorf("%s in %s", errMissingURLPort, endpoint)
-		}
-	}
-	return nil
-}
-
-func urlParseNoSchemaOrPortRequired(endpoints ...string) error {
-	for _, endpoint := range endpoints {
-
-		if strings.Contains(endpoint, "://") {
-			return fmt.Errorf("%s in %s", errNoShemaRequired, endpoint)
-		}
-
-		// Add fake scheme to get an expected result from url.Parse
-		url, err := url.Parse("http://" + endpoint)
-
-		if err != nil {
-			return fmt.Errorf("%s in %s", errMalformedURL, endpoint)
-		}
-
-		if url.Hostname() == "" {
-			return fmt.Errorf("%s in %s", errMissingURLHost, endpoint)
-		}
-
-		if url.Port() != "" {
-			return fmt.Errorf("%s in %s", errNoPortRequired, endpoint)
 		}
 	}
 	return nil

--- a/cmd/parameters.go
+++ b/cmd/parameters.go
@@ -28,6 +28,8 @@ const (
 	errMissingURLHost   = "missing URL Host"
 	errMissingURLPort   = "missing URL Port"
 	errUnexpectedScheme = "unexpected URL Scheme"
+	errNoShemaRequired  = "URL Schema is not required"
+	errNoPortRequired   = "Port is not required"
 )
 
 // urlParse function checks that given string parameters are valid URLs for
@@ -73,6 +75,31 @@ func urlParseNoSchemaRequired(endpoints ...string) error {
 
 		if url.Port() == "" {
 			return fmt.Errorf("%s in %s", errMissingURLPort, endpoint)
+		}
+	}
+	return nil
+}
+
+func urlParseNoSchemaOrPortRequired(endpoints ...string) error {
+	for _, endpoint := range endpoints {
+
+		if strings.Contains(endpoint, "://") {
+			return fmt.Errorf("%s in %s", errNoShemaRequired, endpoint)
+		}
+
+		// Add fake scheme to get an expected result from url.Parse
+		url, err := url.Parse("http://" + endpoint)
+
+		if err != nil {
+			return fmt.Errorf("%s in %s", errMalformedURL, endpoint)
+		}
+
+		if url.Hostname() == "" {
+			return fmt.Errorf("%s in %s", errMissingURLHost, endpoint)
+		}
+
+		if url.Port() != "" {
+			return fmt.Errorf("%s in %s", errNoPortRequired, endpoint)
 		}
 	}
 	return nil

--- a/cmd/parameters_test.go
+++ b/cmd/parameters_test.go
@@ -94,3 +94,39 @@ func TestUrlParseNoSchemaRequired(t *testing.T) {
 		}
 	}
 }
+
+func TestUrlParseNoSchemaOrPortRequired(t *testing.T) {
+
+	testCases := []struct {
+		endpoints     []string
+		expectedError string
+	}{
+		{
+			endpoints:     []string{"localhost:8080", "127.0.0.1:8080"},
+			expectedError: errNoPortRequired,
+		},
+		{
+			endpoints:     []string{"localhost", "127.0.0.1"},
+			expectedError: "",
+		},
+		{
+			endpoints:     []string{""},
+			expectedError: errMissingURLHost,
+		},
+		{
+			endpoints:     []string{"http://localhost:8080", "http://localhost", "https://127.0.0.1:8080", "https://127.0.0.1"},
+			expectedError: errNoShemaRequired,
+		},
+	}
+
+	for _, c := range testCases {
+		for _, e := range c.endpoints {
+			err := urlParseNoSchemaOrPortRequired(e)
+			if c.expectedError == "" {
+				require.NoError(t, err, "Unexpected error")
+				continue
+			}
+			require.Equal(t, err, fmt.Errorf("%s in %s", c.expectedError, e), "Errors do not match")
+		}
+	}
+}

--- a/crypto/certs.go
+++ b/crypto/certs.go
@@ -28,7 +28,7 @@ import (
 	"time"
 )
 
-func NewTlsCerts(path, host string) (string, string, error) {
+func NewSelfSignedCert(path, host string) (string, string, error) {
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return "", "", err

--- a/crypto/certs.go
+++ b/crypto/certs.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package keys
+package crypto
 
 import (
 	"crypto/rand"
@@ -22,16 +22,17 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"fmt"
 	"math/big"
 	"net"
 	"os"
 	"time"
 )
 
-func GenerateTlsCert(path string) (string, error) {
+func NewTlsCerts(path, hostname string) (string, string, string, error) {
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		return "", err
+		return "", "", "", err
 	}
 
 	notBefore := time.Now()
@@ -40,7 +41,7 @@ func GenerateTlsCert(path string) (string, error) {
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {
-		return "", err
+		return "", "", "", err
 	}
 
 	template := x509.Certificate{
@@ -55,41 +56,41 @@ func GenerateTlsCert(path string) (string, error) {
 		BasicConstraintsValid: true,
 	}
 
-	ip := net.ParseIP("127.0.0.1")
+	ip := net.ParseIP(hostname)
 	template.IPAddresses = append(template.IPAddresses, ip)
 	template.IsCA = true
 	template.KeyUsage |= x509.KeyUsageCertSign
 
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
 	if err != nil {
-		return "", err
+		return "", "", "", err
 	}
 
-	certOut, err := os.Create(path + "/cert.pem")
+	certOut, err := os.Create(path + "/qed_cert.pem")
 	if err != nil {
-		return "", err
+		return "", "", "", err
 	}
 
 	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
-		return "", err
+		return "", "", "", err
 	}
 
 	if err := certOut.Close(); err != nil {
-		return "", err
+		return "", "", "", err
 	}
 
-	keyOut, err := os.OpenFile(path+"/key.pem", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	keyOut, err := os.OpenFile(path+"/qed_key.pem", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
-		return "", err
+		return "", "", "", err
 	}
 	block := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)}
 	if err := pem.Encode(keyOut, block); err != nil {
-		return "", err
+		return "", "", "", err
 	}
 
 	if err := keyOut.Close(); err != nil {
-		return "", err
+		return "", "", "", err
 	}
 
-	return path, nil
+	return fmt.Sprintf("%v", certOut), fmt.Sprintf("%v", keyOut), hostname, nil
 }

--- a/crypto/certs.go
+++ b/crypto/certs.go
@@ -21,6 +21,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/asn1"
 	"encoding/pem"
 	"math/big"
 	"net"
@@ -30,10 +31,10 @@ import (
 
 // NewSelfSignedCert generates a new Tls certificate and private key.
 // First parameter is the full path to the output directory where the
-// certificate and the key be stored. The second one is the host
+// certificate and the key will be stored. The second one is the host
 // (DNSName or IPAddr) for which we are signing the certificate.
 // The function output is the full path to our new certificate and
-// private key. Eg: (/var/tmp/qed_ed25519, /var/tmp/qed_ed25519.pub, nil)
+// private key. Eg: (/var/tmp/qed_key.pem, /var/tmp/qed_cert.pem, nil)
 func NewSelfSignedCert(path, host string) (string, string, error) {
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -93,8 +94,8 @@ func NewSelfSignedCert(path, host string) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	block := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)}
-	if err := pem.Encode(keyOut, block); err != nil {
+	keyBlock := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)}
+	if err := pem.Encode(keyOut, keyBlock); err != nil {
 		return "", "", err
 	}
 
@@ -103,4 +104,96 @@ func NewSelfSignedCert(path, host string) (string, string, error) {
 	}
 
 	return certOut.Name(), keyOut.Name(), nil
+}
+
+// NewCsrRequest generates a private key and Certificate Signing Request(CSR).
+// This enables us to use custom CA to sign the server certificates.
+// First parameter is the full path to the output directory where the
+// CSR and the key will be stored. The second one is the host
+// (DNSName or IPAddr) for which we are creating the request.
+// The function output is the full path to our new CSR and private key.
+// Eg: (/var/tmp/qed.csr, /var/tmp/qed_key.pem, nil)
+func NewCsrRequest(path, host string) (string, string, error) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return "", "", err
+	}
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(1 * time.Hour)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return "", "", err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Acme Co"},
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	ip := net.ParseIP(host)
+	// Check if host parameter is DNSName or IPAddr
+	if ip == nil {
+		template.DNSNames = append(template.DNSNames, host)
+	} else {
+		template.IPAddresses = append(template.IPAddresses, ip)
+	}
+	template.IsCA = true
+	template.KeyUsage |= x509.KeyUsageCertSign
+
+	var csrTemplate = x509.CertificateRequest{
+		Subject: pkix.Name{
+			Organization: []string{"Acme Co"},
+		},
+		SignatureAlgorithm: x509.SHA512WithRSA,
+		ExtraExtensions: []pkix.Extension{
+			{
+				Id:       asn1.ObjectIdentifier{2, 5, 29, 19},
+				Critical: true,
+			},
+		},
+	}
+
+	csrCertificate, err := x509.CreateCertificateRequest(rand.Reader, &csrTemplate, priv)
+	if err != nil {
+		return "", "", err
+	}
+
+	csrBlock := &pem.Block{
+		Type: "CERTIFICATE REQUEST", Bytes: csrCertificate,
+	}
+
+	csrOut, err := os.OpenFile(path+"/qed.csr", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return "", "", err
+	}
+
+	if err := pem.Encode(csrOut, csrBlock); err != nil {
+		return "", "", err
+	}
+
+	keyOut, err := os.OpenFile(path+"/qed_key.pem", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return "", "", err
+	}
+
+	keyBlock := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)}
+	if err := pem.Encode(keyOut, keyBlock); err != nil {
+		return "", "", err
+	}
+
+	if err := keyOut.Close(); err != nil {
+		return "", "", err
+	}
+
+	return csrOut.Name(), keyOut.Name(), nil
 }

--- a/crypto/certs.go
+++ b/crypto/certs.go
@@ -28,6 +28,12 @@ import (
 	"time"
 )
 
+// NewSelfSignedCert generates a new Tls certificate and private key.
+// First parameter is the full path to the output directory where the
+// certificate and the key be stored. The second one is the host
+// (DNSName or IPAddr) for which we are signing the certificate.
+// The function output is the full path to our new certificate and
+// private key. Eg: (/var/tmp/qed_ed25519, /var/tmp/qed_ed25519.pub, nil)
 func NewSelfSignedCert(path, host string) (string, string, error) {
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {

--- a/crypto/keys.go
+++ b/crypto/keys.go
@@ -25,6 +25,9 @@ import (
 )
 
 // NewEd25519SignerKeysFile generates a new private/public signer key.
+// Input parameter is the full path to the output directory where the keys
+// will be stored. The function output is the full path to our new signer keys
+// and an error. Eg: (/var/tmp/qed_ed25519, /var/tmp/qed_ed25519.pub, nil)
 func NewEd25519SignerKeysFile(path string) (string, string, error) {
 	outPriv := path + "/qed_ed25519"
 	outPub := outPriv + ".pub"

--- a/deploy/aws/config_build.sh
+++ b/deploy/aws/config_build.sh
@@ -48,7 +48,7 @@ fi
 
 if [ ! -f ${sign_path} ]; then
     #build shared signing key
-    $QED generate self-signed-cert --path ${cert_path} --host 127.0.0.1
+    $QED generate self-signed-cert --path ${cert_path} --host qed.awesome.aws
 fi
 
 )

--- a/deploy/aws/config_build.sh
+++ b/deploy/aws/config_build.sh
@@ -48,7 +48,7 @@ fi
 
 if [ ! -f ${sign_path} ]; then
     #build shared signing key
-    $QED generate tlscerts --path ${cert_path} --host 127.0.0.1
+    $QED generate self-signed-cert --path ${cert_path} --host 127.0.0.1
 fi
 
 )

--- a/deploy/aws/config_build.sh
+++ b/deploy/aws/config_build.sh
@@ -1,4 +1,18 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# Copyright 2018-2019 Banco Bilbao Vizcaya Argentaria, S.A.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 function _readlink() { (
   # INFO: readlink does not exist on OSX ¯\_(ツ)_/¯

--- a/deploy/aws/config_build.sh
+++ b/deploy/aws/config_build.sh
@@ -14,9 +14,7 @@ pub=$(_readlink ./config_files)
 tdir=$(mktemp -d /tmp/qed_build.XXX)
 
 sign_path=${pub}
-cert_path=${pub}/server.crt
-key_path=${pub}/server.key
-node_path=${pub}/node_exporter
+cert_path=${pub}
 
 (
 cd ${tdir}
@@ -34,37 +32,9 @@ if [ ! -f ${sign_path} ]; then
     $QED generate signerkeys --path ${sign_path}
 fi
 
-if [ ! -f ${cert_path} ] && [ ! -f ${key_path} ]; then
-
-    #build shared server cert
-    openssl req \
-        -newkey rsa:2048 \
-        -nodes \
-        -days 3650 \
-        -x509 \
-        -keyout ca.key \
-        -out ca.crt \
-        -subj "/CN=*"
-    openssl req \
-        -newkey rsa:2048 \
-        -nodes \
-        -keyout server.key \
-        -out server.csr \
-        -subj "/C=GB/ST=London/L=London/O=Global Security/OU=IT Department/CN=*"
-    openssl x509 \
-        -req \
-        -days 365 \
-        -sha256 \
-        -in server.csr \
-        -CA ca.crt \
-        -CAkey ca.key \
-        -CAcreateserial \
-        -out server.crt \
-        -extfile <(echo subjectAltName = IP:127.0.0.1)
-
-    cp server.crt ${cert_path}
-    cp server.key ${key_path}
-
+if [ ! -f ${sign_path} ]; then
+    #build shared signing key
+    $QED generate tlscerts --path ${cert_path} --host 127.0.0.1
 fi
 
 )

--- a/deploy/provision/tasks/common/config.yml
+++ b/deploy/provision/tasks/common/config.yml
@@ -23,6 +23,6 @@
     creates: config_files/qed_ed25519
 
 - name: Create SSL certs
-  shell: > GOOS="" GOARCH="" $QED generate tlscerts --path config_files --host 127.0.0.1
+  shell: > GOOS="" GOARCH="" $QED generate self-signed-cert --path config_files --host 127.0.0.1
 
   

--- a/deploy/provision/tasks/common/config.yml
+++ b/deploy/provision/tasks/common/config.yml
@@ -23,32 +23,6 @@
     creates: config_files/qed_ed25519
 
 - name: Create SSL certs
-  shell: >
-    openssl req \
-        -newkey rsa:2048 \
-        -nodes \
-        -days 3650 \
-        -x509 \
-        -keyout config_files/ca.key \
-        -out config_files/ca.crt \
-        -subj "/CN=*"
-    openssl req \
-        -newkey rsa:2048 \
-        -nodes \
-        -keyout config_files/server.key \
-        -out config_files/server.csr \
-        -subj "/C=GB/ST=London/L=London/O=Global Security/OU=IT Department/CN=*"
-    openssl x509 \
-        -req \
-        -days 365 \
-        -sha256 \
-        -in config_files/server.csr \
-        -CA config_files/ca.crt \
-        -CAkey config_files/ca.key \
-        -CAcreateserial \
-        -out config_files/server.crt \
-        ## Not present in all OpenSSL version 
-        ## -extfile <(echo subjectAltName = IP:127.0.0.1)
-  args:
-    creates: config_files/server.crt
+  shell: > GOOS="" GOARCH="" $QED generate tlscerts --path config_files --host 127.0.0.1
+
   

--- a/deploy/provision/tasks/common/config.yml
+++ b/deploy/provision/tasks/common/config.yml
@@ -23,6 +23,6 @@
     creates: config_files/qed_ed25519
 
 - name: Create SSL certs
-  shell: > GOOS="" GOARCH="" $QED generate self-signed-cert --path config_files --host 127.0.0.1
+  shell: GOOS="" GOARCH="" $QED generate self-signed-cert --path config_files --host qed.awesome.lan
 
   

--- a/docs/contribute/development.md
+++ b/docs/contribute/development.md
@@ -13,7 +13,7 @@ go run main.go generate signerkeys
 
 
 # Generation of self-signed(x509) public key (PEM-encodings qed_key.pem|qed_cert.pem)
-go run main.go generate self-signed-cert --host 127.0.0.1
+go run main.go generate self-signed-cert --host qed.awesome.lan
 ```
 
 ## Useful commands

--- a/docs/contribute/development.md
+++ b/docs/contribute/development.md
@@ -1,0 +1,31 @@
+## Environment
+
+We use the [Go](https://golang.org) programming language and set up the
+environment as described in its [documentation](https://golang.org/doc/code.html)
+
+## Self-signed certificate
+
+```
+cd ~/.ssh/
+
+# Generate private key (qed_ed25519|.pub)
+go run main.go generate signerkeys
+
+
+# Generation of self-signed(x509) public key (PEM-encodings qed_key.pem|qed_cert.pem)
+go run main.go generate self-signed-cert --host 127.0.0.1
+```
+
+## Useful commands
+
+- Go [documentation server](http://localhost:6061/pkg/github.com/bbva/qed/)
+
+```
+godoc -http=:6061 # http://localhost:6061/pkg/github.com/bbva/qed/
+```
+
+- Test everything
+
+```
+go test -v "${GOPATH}"/src/github.com/bbva/qed/...
+```

--- a/tests/build_certs
+++ b/tests/build_certs
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function _readlink() { (
-  # INFO: readlink does not exists on OSX ¯\_(ツ)_/¯
+  # INFO: readlink does not exist on OSX ¯\_(ツ)_/¯
   cd $(dirname $1)
   echo $PWD/$(basename $1)
 ) }
@@ -10,52 +10,31 @@ function _readlink() { (
 CGO_LDFLAGS_ALLOW='.*'
 QED="go run $GOPATH/src/github.com/bbva/qed/main.go"
 
-pub=$(_readlink /var/tmp/certs)
+pub=$(_readlink ./config_files)
 tdir=$(mktemp -d /tmp/qed_build.XXX)
-mkdir -p $pub
+
 sign_path=${pub}
-cert_path=${pub}/server.crt
-key_path=${pub}/server.key
+cert_path=${pub}
 
 (
 cd ${tdir}
+
+if [ ! -f ${node_path} ]; then (
+    version=0.17.0
+    folder=node_exporter-${version}.linux-amd64
+    link=https://github.com/prometheus/node_exporter/releases/download/v${version}/${folder}.tar.gz
+    wget -qO- ${link} | tar xvz -C ./
+    cp ${folder}/node_exporter ${node_path}
+) fi
 
 if [ ! -f ${sign_path} ]; then
     #build shared signing key
     $QED generate signerkeys --path ${sign_path}
 fi
 
-if [ ! -f ${cert_path} ] && [ ! -f ${key_path} ]; then
-
-    #build shared server cert
-    openssl req \
-        -newkey rsa:2048 \
-        -nodes \
-        -days 3650 \
-        -x509 \
-        -keyout ca.key \
-        -out ca.crt \
-        -subj "/CN=*"
-    openssl req \
-        -newkey rsa:2048 \
-        -nodes \
-        -keyout server.key \
-        -out server.csr \
-        -subj "/C=GB/ST=London/L=London/O=Global Security/OU=IT Department/CN=*"
-    openssl x509 \
-        -req \
-        -days 365 \
-        -sha256 \
-        -in server.csr \
-        -CA ca.crt \
-        -CAkey ca.key \
-        -CAcreateserial \
-        -out server.crt \
-        -extfile <(echo subjectAltName = IP:127.0.0.1)
-
-    cp server.crt ${cert_path}
-    cp server.key ${key_path}
-
+if [ ! -f ${sign_path} ]; then
+    #build shared signing key
+    $QED generate tlscerts --path ${cert_path} --host 127.0.0.1
 fi
 
 )

--- a/tests/build_certs
+++ b/tests/build_certs
@@ -40,6 +40,6 @@ fi
 
 if [ ! -f ${sign_path} ]; then
     #build shared signing key
-    $QED generate tlscerts --path ${cert_path} --host 127.0.0.1
+    $QED generate self-signed-cert --path ${cert_path} --host 127.0.0.1
 fi
 )

--- a/tests/build_certs
+++ b/tests/build_certs
@@ -40,6 +40,6 @@ fi
 
 if [ ! -f ${sign_path} ]; then
     #build shared signing key
-    $QED generate self-signed-cert --path ${cert_path} --host 127.0.0.1
+    $QED generate self-signed-cert --path ${cert_path} --host localhost
 fi
 )

--- a/tests/build_certs
+++ b/tests/build_certs
@@ -1,4 +1,18 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# Copyright 2018-2019 Banco Bilbao Vizcaya Argentaria, S.A.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 function _readlink() { (
   # INFO: readlink does not exist on OSX ¯\_(ツ)_/¯
@@ -10,7 +24,7 @@ function _readlink() { (
 CGO_LDFLAGS_ALLOW='.*'
 QED="go run $GOPATH/src/github.com/bbva/qed/main.go"
 
-pub=$(_readlink ./config_files)
+pub=$(_readlink /var/tmp)
 tdir=$(mktemp -d /tmp/qed_build.XXX)
 
 sign_path=${pub}

--- a/tests/build_certs
+++ b/tests/build_certs
@@ -33,14 +33,6 @@ cert_path=${pub}
 (
 cd ${tdir}
 
-if [ ! -f ${node_path} ]; then (
-    version=0.17.0
-    folder=node_exporter-${version}.linux-amd64
-    link=https://github.com/prometheus/node_exporter/releases/download/v${version}/${folder}.tar.gz
-    wget -qO- ${link} | tar xvz -C ./
-    cp ${folder}/node_exporter ${node_path}
-) fi
-
 if [ ! -f ${sign_path} ]; then
     #build shared signing key
     $QED generate signerkeys --path ${sign_path}
@@ -50,5 +42,4 @@ if [ ! -f ${sign_path} ]; then
     #build shared signing key
     $QED generate tlscerts --path ${cert_path} --host 127.0.0.1
 fi
-
 )

--- a/tests/e2e/server_test.go
+++ b/tests/e2e/server_test.go
@@ -52,7 +52,7 @@ func TestStart(t *testing.T) {
 			var resp *http.Response
 			var err error
 			retry(3, 2*time.Second, func() error {
-				resp, err = doReq("GET", "http://localhost:8800/info", "APIKey", nil)
+				resp, err = doReq("GET", "http://localhost:8800/info", "APIKey", false, nil)
 				return err
 			})
 			spec.NoError(t, err, "Subprocess must not exit with non-zero status")
@@ -63,7 +63,7 @@ func TestStart(t *testing.T) {
 			var resp *http.Response
 			var err error
 			retry(3, 1*time.Second, func() error {
-				resp, err = doReq("GET", "http://localhost:8800/xD", "APIKey", nil)
+				resp, err = doReq("GET", "http://localhost:8800/xD", "APIKey", false, nil)
 				return err
 			})
 			spec.NoError(t, err, "Error getting response from server")
@@ -77,7 +77,7 @@ func TestStart(t *testing.T) {
 			var resp *http.Response
 			var err error
 			retry(3, 1*time.Second, func() error {
-				resp, err = doReq("GET", "http://localhost:8600/metrics", "APIKey", nil)
+				resp, err = doReq("GET", "http://localhost:8600/metrics", "APIKey", false, nil)
 				return err
 			})
 			spec.NoError(t, err, "Subprocess must not exit with non-zero status")
@@ -87,7 +87,7 @@ func TestStart(t *testing.T) {
 	})
 
 }
-func TestStartTls(t *testing.T) {
+func TestStartTlsIgnoreCA(t *testing.T) {
 	before, after := newServerSetup(0, true)
 	let, report := spec.New()
 	defer func() {
@@ -101,7 +101,7 @@ func TestStartTls(t *testing.T) {
 			var resp *http.Response
 			var err error
 			retry(3, 2*time.Second, func() error {
-				resp, err = doReq("GET", "https://localhost:8800/info", "APIKey", nil)
+				resp, err = doReq("GET", "https://localhost:8800/info", "APIKey", true, nil)
 				return err
 			})
 			spec.NoError(t, err, "Subprocess must not exit with non-zero status")
@@ -112,7 +112,7 @@ func TestStartTls(t *testing.T) {
 			var resp *http.Response
 			var err error
 			retry(3, 1*time.Second, func() error {
-				resp, err = doReq("GET", "https://localhost:8800/xD", "APIKey", nil)
+				resp, err = doReq("GET", "https://localhost:8800/xD", "APIKey", true, nil)
 				return err
 			})
 			spec.NoError(t, err, "Error getting response from server")
@@ -126,7 +126,7 @@ func TestStartTls(t *testing.T) {
 			var resp *http.Response
 			var err error
 			retry(3, 1*time.Second, func() error {
-				resp, err = doReq("GET", "http://localhost:8600/metrics", "APIKey", nil)
+				resp, err = doReq("GET", "http://localhost:8600/metrics", "APIKey", true, nil)
 				return err
 			})
 			spec.NoError(t, err, "Subprocess must not exit with non-zero status")
@@ -164,7 +164,7 @@ func TestStartCluster(t *testing.T) {
 		retry(3, 2*time.Second, func() error {
 			var subErr error
 			retry(3, 2*time.Second, func() error {
-				resp, subErr = doReq("GET", "http://localhost:8800/info/shards", "APIKey", nil)
+				resp, subErr = doReq("GET", "http://localhost:8800/info/shards", "APIKey", false, nil)
 				return subErr
 			})
 			if subErr != nil {

--- a/tests/e2e/server_test.go
+++ b/tests/e2e/server_test.go
@@ -189,7 +189,7 @@ func TestStartCluster(t *testing.T) {
 			}
 			shards := len(m["shards"].(map[string]interface{}))
 			if shards != 3 {
-				mainErr = fmt.Errorf("not enought shards: %v", shards)
+				mainErr = fmt.Errorf("not enough shards: %v", shards)
 				return mainErr
 			}
 			return nil

--- a/tests/e2e/setup_for_test.go
+++ b/tests/e2e/setup_for_test.go
@@ -150,7 +150,7 @@ func newServerSetup(id int, tls bool) (func() error, func() error) {
 		}
 		conf := configQedServer(id, path, signKeyPath, path, tls)
 		if tls {
-			_, _, err = crypto.NewTlsCerts(path, "localhost")
+			_, _, err = crypto.NewSelfSignedCert(path, "localhost")
 			if err != nil {
 				return err
 			}

--- a/tests/e2e/setup_for_test.go
+++ b/tests/e2e/setup_for_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/bbva/qed/crypto"
 	"github.com/bbva/qed/crypto/hashing"
 	"github.com/bbva/qed/server"
-	"github.com/bbva/qed/testutils/keys"
 	"github.com/bbva/qed/testutils/notifierstore"
 	"github.com/bbva/qed/testutils/scope"
 )
@@ -115,8 +114,8 @@ func configQedServer(id int, pathDB, signPath, tlsPath string, tls bool) *server
 	conf.RaftPath = pathDB + "raft"
 	conf.PrivateKeyPath = signPath
 	if tls {
-		conf.SSLCertificate = tlsPath + "/cert.pem"
-		conf.SSLCertificateKey = tlsPath + "/key.pem"
+		conf.SSLCertificate = tlsPath + "/qed_cert.pem"
+		conf.SSLCertificateKey = tlsPath + "/qed_key.pem"
 	}
 	conf.EnableTLS = tls
 
@@ -146,7 +145,7 @@ func newServerSetup(id int, tls bool) (func() error, func() error) {
 			return err
 		}
 		if tls {
-			tlsPath, err = keys.GenerateTlsCert(path)
+			tlsPath, err = crypto.NewTlsCerts(path)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Improve our generate command in **QED** command tool and enable it to generate self-signed **Tls** certificate.
This feature allow us to remove **openssl** (external|sys tools) dependency in our test scripts.