### PR TITLE
Update source to support Rocksdb v6.2.4

### DIFF
--- a/rocksdb/extended.cpp
+++ b/rocksdb/extended.cpp
@@ -169,16 +169,6 @@ rocksdb_statistics_t* rocksdb_create_statistics() {
     return result;
 }
 
-int rocksdb_property_int_cf(
-    rocksdb_t* db, rocksdb_column_family_handle_t* column_family,
-    const char* propname, uint64_t *out_val) {
-    if (db->rep->GetIntProperty(column_family->rep, Slice(propname), out_val)) {
-        return 0;
-    } else {
-        return -1;
-    }
-}
-
 void rocksdb_options_set_statistics(
     rocksdb_options_t* opts, 
     rocksdb_statistics_t* stats) {
@@ -189,13 +179,13 @@ void rocksdb_options_set_statistics(
 
 rocksdb_stats_level_t rocksdb_statistics_stats_level(
     rocksdb_statistics_t* stats) {
-        return static_cast<rocksdb_stats_level_t>(stats->rep->stats_level_);
+        return static_cast<rocksdb_stats_level_t>(stats->rep->get_stats_level());
 }
 
 void rocksdb_statistics_set_stats_level(
     rocksdb_statistics_t* stats,
     rocksdb_stats_level_t level) {
-        stats->rep->stats_level_ = static_cast<StatsLevel>(level);
+        stats->rep->set_stats_level(static_cast<StatsLevel>(level));
 }
 
 void rocksdb_statistics_reset(

--- a/rocksdb/extended.h
+++ b/rocksdb/extended.h
@@ -43,13 +43,6 @@ typedef struct rocksdb_histogram_data_t rocksdb_histogram_data_t;
 
 extern rocksdb_statistics_t* rocksdb_create_statistics();
 
-/* returns 0 on success, -1 otherwise */
-extern int rocksdb_property_int_cf(
-    rocksdb_t* db, rocksdb_column_family_handle_t* column_family,
-    const char* propname, uint64_t *out_val);
-
-/* Options */
-
 extern void rocksdb_options_set_atomic_flush(
     rocksdb_options_t*, unsigned char);
 


### PR DESCRIPTION
Minor changes in statistics -> https://github.com/facebook/rocksdb/pull/5030
Remove some functiones in our extended bindings which are no more
required by this new version of Rocksdb

Related #114